### PR TITLE
fix: show gallery picker in correct section

### DIFF
--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -474,28 +474,6 @@ export default function Painel() {
                                     ))}
                                 </select>
                                 <div className="mt-2 flex items-center gap-2">
-                                    <Dialog open={imagePickerOpen && imagePickerFor === 'featured'} onOpenChange={(o) => { setImagePickerOpen(o); if (!o) setImagePickerFor(null); }}>
-                                        <DialogTrigger asChild>
-                                            <Button type="button" variant="secondary" onClick={() => { setImagePickerFor('featured'); setImagePickerOpen(true); }}>Selecionar da galeria</Button>
-                                        </DialogTrigger>
-                                        <DialogContent className="sm:max-w-3xl">
-                                            <DialogHeader>
-                                                <DialogTitle>Escolher imagem</DialogTitle>
-                                            </DialogHeader>
-                                            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
-                                                {images.map((img) => (
-                                                    <button key={img.id} type="button" className="overflow-hidden rounded-md border focus:outline-none focus:ring-2 focus:ring-ring" onClick={() => { setNewFeatured((s) => ({ ...s, image_id: img.id })); setImagePickerOpen(false); setImagePickerFor(null); }}>
-                                                        <img src={img.url} alt={img.original_name} className="h-28 w-full object-cover" />
-                                                    </button>
-                                                ))}
-                                            </div>
-                                        </DialogContent>
-                                    </Dialog>
-                                    {newFeatured.image_id && (
-                                        <img src={images.find((i) => i.id === newFeatured.image_id)?.url} alt="Selecionada" className="h-10 w-14 rounded object-cover" />
-                                    )}
-                                </div>
-                                <div className="mt-2 flex items-center gap-2">
                                     <Dialog open={imagePickerOpen && imagePickerFor === 'slide'} onOpenChange={(o) => { setImagePickerOpen(o); if (!o) setImagePickerFor(null); }}>
                                         <DialogTrigger asChild>
                                             <Button type="button" variant="secondary" onClick={() => { setImagePickerFor('slide'); setImagePickerOpen(true); }}>Selecionar da galeria</Button>
@@ -623,6 +601,28 @@ export default function Painel() {
                                         </option>
                                     ))}
                                 </select>
+                                <div className="mt-2 flex items-center gap-2">
+                                    <Dialog open={imagePickerOpen && imagePickerFor === 'featured'} onOpenChange={(o) => { setImagePickerOpen(o); if (!o) setImagePickerFor(null); }}>
+                                        <DialogTrigger asChild>
+                                            <Button type="button" variant="secondary" onClick={() => { setImagePickerFor('featured'); setImagePickerOpen(true); }}>Selecionar da galeria</Button>
+                                        </DialogTrigger>
+                                        <DialogContent className="sm:max-w-3xl">
+                                            <DialogHeader>
+                                                <DialogTitle>Escolher imagem</DialogTitle>
+                                            </DialogHeader>
+                                            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+                                                {images.map((img) => (
+                                                    <button key={img.id} type="button" className="overflow-hidden rounded-md border focus:outline-none focus:ring-2 focus:ring-ring" onClick={() => { setNewFeatured((s) => ({ ...s, image_id: img.id })); setImagePickerOpen(false); setImagePickerFor(null); }}>
+                                                        <img src={img.url} alt={img.original_name} className="h-28 w-full object-cover" />
+                                                    </button>
+                                                ))}
+                                            </div>
+                                        </DialogContent>
+                                    </Dialog>
+                                    {newFeatured.image_id && (
+                                        <img src={images.find((i) => i.id === newFeatured.image_id)?.url} alt="Selecionada" className="h-10 w-14 rounded object-cover" />
+                                    )}
+                                </div>
                             </div>
                             <div>
                                 <Label>Título</Label>


### PR DESCRIPTION
## Summary
- remove misplaced gallery picker from Hero Slides
- add gallery picker to Featured Properties section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: eslint errors in unrelated files)*
- `npm run types` *(fails: TypeScript errors in resources/js/routes/password/index.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68bf9ea6f6f8832caa30b0f2c9e6d756