### PR TITLE
Simplify button labels on admin panel

### DIFF
--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -460,10 +460,10 @@ export default function Painel() {
                     <>
                         <div className="flex flex-col gap-4">
                             <Button className="w-auto self-start" onClick={() => setHeroModalOpen(true)}>
-                                Configurar Hero Slides
+                                Slides
                             </Button>
                             <Button className="w-auto self-start" onClick={() => setFeaturedModalOpen(true)}>
-                                Configurar Imóveis em Destaque
+                                Destaques
                             </Button>
                         </div>
 
@@ -474,8 +474,14 @@ export default function Painel() {
                                         <DialogTitle>Hero Slides</DialogTitle>
                                         <div className="flex items-center gap-2 text-sm text-muted-foreground">
                                             <span>{slidesLoading ? 'Carregando…' : `${slides.length} itens`}</span>
-                                            <Button className="w-auto" variant="secondary" onClick={refreshSlides} disabled={slidesLoading}>
-                                                Atualizar
+                                            <Button
+                                                className="w-auto"
+                                                variant="secondary"
+                                                onClick={refreshSlides}
+                                                disabled={slidesLoading}
+                                                title="Atualizar"
+                                            >
+                                                ↻
                                             </Button>
                                         </div>
                                     </div>
@@ -502,7 +508,7 @@ export default function Painel() {
                                                                 setImagePickerOpen(true);
                                                             }}
                                                         >
-                                                            Selecionar da galeria
+                                                            Galeria
                                                         </Button>
                                                     </DialogTrigger>
                                                     <DialogContent className="sm:max-w-3xl">
@@ -622,8 +628,13 @@ export default function Painel() {
                                         </label>
                                     </div>
                                     <div className="flex items-end gap-2">
-                                        <Button className="w-auto" onClick={submitSlide} disabled={creatingSlide}>
-                                            {creatingSlide ? 'Adicionando…' : 'Adicionar Slide'}
+                                        <Button
+                                            className="w-auto"
+                                            onClick={submitSlide}
+                                            disabled={creatingSlide}
+                                            title="Adicionar Slide"
+                                        >
+                                            {creatingSlide ? '…' : '+'}
                                         </Button>
                                     </div>
                                     <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
@@ -680,8 +691,14 @@ export default function Painel() {
                                         <DialogTitle>Imóveis em Destaque</DialogTitle>
                                         <div className="flex items-center gap-2 text-sm text-muted-foreground">
                                             <span>{featuredLoading ? 'Carregando…' : `${featured.length} itens`}</span>
-                                            <Button className="w-auto" variant="secondary" onClick={refreshFeatured} disabled={featuredLoading}>
-                                                Atualizar
+                                            <Button
+                                                className="w-auto"
+                                                variant="secondary"
+                                                onClick={refreshFeatured}
+                                                disabled={featuredLoading}
+                                                title="Atualizar"
+                                            >
+                                                ↻
                                             </Button>
                                         </div>
                                     </div>
@@ -708,7 +725,7 @@ export default function Painel() {
                                                                 setImagePickerOpen(true);
                                                             }}
                                                         >
-                                                            Selecionar da galeria
+                                                            Galeria
                                                         </Button>
                                                     </DialogTrigger>
                                                     <DialogContent className="sm:max-w-3xl">
@@ -855,8 +872,9 @@ export default function Painel() {
                                                     setNewFeatured((s) => ({ ...s, features: [...(s.features ?? []), v] }));
                                                     setFeatureInput('');
                                                 }}
+                                                title="Adicionar"
                                             >
-                                                Adicionar
+                                                +
                                             </Button>
                                         </div>
                                         {(newFeatured.features ?? []).length > 0 && (
@@ -885,8 +903,13 @@ export default function Painel() {
                                         )}
                                     </div>
                                     <div className="flex items-end gap-2">
-                                        <Button className="w-auto" onClick={submitFeatured} disabled={creatingFeatured}>
-                                            {creatingFeatured ? 'Adicionando…' : 'Adicionar Destaque'}
+                                        <Button
+                                            className="w-auto"
+                                            onClick={submitFeatured}
+                                            disabled={creatingFeatured}
+                                            title="Adicionar Destaque"
+                                        >
+                                            {creatingFeatured ? '…' : '+'}
                                         </Button>
                                     </div>
                                     <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
@@ -906,10 +929,10 @@ export default function Painel() {
                                                     </div>
                                                     <div className="flex shrink-0 items-center gap-1">
                                                         <Button className="w-auto" variant="secondary" onClick={() => moveFeatured(f.id, -1)} title="Subir">
-                                                            Subir
+                                                            ↑
                                                         </Button>
                                                         <Button className="w-auto" variant="secondary" onClick={() => moveFeatured(f.id, 1)} title="Descer">
-                                                            Descer
+                                                            ↓
                                                         </Button>
                                                         <Button
                                                             className="w-auto"


### PR DESCRIPTION
## Summary
- Replace verbose admin panel button labels with concise titles
- Use icons for refresh and add actions to reduce clutter
- Standardize gallery picker label to "Galeria"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 22 problems)*
- `npm run format:check` *(warnings: code style issues in 83 files)*

------
https://chatgpt.com/codex/tasks/task_b_68c0aae69940832c9d2e0f54a864f398