### PR TITLE
feat: add image preview with zoom

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+
+interface ImagePreviewProps {
+    src: string;
+    titulo?: string | null;
+    subtitulo?: string | null;
+    preco?: string | null;
+    quartos?: number | string | null;
+    banheiros?: number | string | null;
+    area?: string | null;
+    bairro?: string | null;
+}
+
+export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, banheiros, area, bairro }: ImagePreviewProps) {
+    const [zoom, setZoom] = useState(1);
+
+    const zoomIn = () => setZoom((z) => Math.min(z + 0.25, 3));
+    const zoomOut = () => setZoom((z) => Math.max(z - 0.25, 0.5));
+
+    return (
+        <div className="relative inline-block">
+            <div className="h-40 w-64 overflow-hidden rounded-md">
+                <img
+                    src={src}
+                    alt={titulo ?? ''}
+                    className="h-full w-full object-cover transition-transform"
+                    style={{ transform: `scale(${zoom})` }}
+                />
+                <div className="absolute inset-0 bg-black/40" />
+                <div className="absolute inset-0 flex flex-col justify-between p-4 text-white">
+                    <div>
+                        {bairro && <span className="rounded bg-black/50 px-2 py-1 text-xs">{bairro}</span>}
+                        {titulo && <h3 className="mt-2 text-lg leading-tight font-bold">{titulo}</h3>}
+                        {subtitulo && <p className="text-sm">{subtitulo}</p>}
+                    </div>
+                    <div>
+                        {preco && <div className="text-xl font-bold">{preco}</div>}
+                        {(quartos || banheiros || area) && (
+                            <div className="mt-1 flex gap-2 text-xs">
+                                {quartos && <span>{quartos}q</span>}
+                                {banheiros && <span>{banheiros}b</span>}
+                                {area && <span>{area}</span>}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+            <div className="absolute right-2 bottom-2 flex gap-1">
+                <button type="button" onClick={zoomOut} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
+                    -
+                </button>
+                <button type="button" onClick={zoomIn} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
+                    +
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -1,3 +1,4 @@
+import ImagePreview from '@/components/ImagePreview';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -534,10 +535,15 @@ export default function Painel() {
                                                     </DialogContent>
                                                 </Dialog>
                                                 {newSlide.image_id && (
-                                                    <img
-                                                        src={images.find((i) => i.id === newSlide.image_id)?.url}
-                                                        alt="Selecionada"
-                                                        className="h-10 w-14 rounded object-cover"
+                                                    <ImagePreview
+                                                        src={images.find((i) => i.id === newSlide.image_id)?.url ?? ''}
+                                                        titulo={newSlide.title}
+                                                        subtitulo={newSlide.subtitle}
+                                                        preco={newSlide.price}
+                                                        quartos={newSlide.bedrooms}
+                                                        banheiros={newSlide.bathrooms}
+                                                        area={newSlide.area}
+                                                        bairro={newSlide.neighborhood}
                                                     />
                                                 )}
                                             </div>
@@ -628,12 +634,7 @@ export default function Painel() {
                                         </label>
                                     </div>
                                     <div className="flex items-end gap-2">
-                                        <Button
-                                            className="w-auto"
-                                            onClick={submitSlide}
-                                            disabled={creatingSlide}
-                                            title="Adicionar Slide"
-                                        >
+                                        <Button className="w-auto" onClick={submitSlide} disabled={creatingSlide} title="Adicionar Slide">
                                             {creatingSlide ? '…' : '+'}
                                         </Button>
                                     </div>
@@ -653,10 +654,20 @@ export default function Painel() {
                                                         <div className="text-xs text-muted-foreground">{s.price}</div>
                                                     </div>
                                                     <div className="flex shrink-0 items-center gap-1">
-                                                        <Button className="w-auto" variant="secondary" onClick={() => moveSlide(s.id, -1)} title="Subir">
+                                                        <Button
+                                                            className="w-auto"
+                                                            variant="secondary"
+                                                            onClick={() => moveSlide(s.id, -1)}
+                                                            title="Subir"
+                                                        >
                                                             ↑
                                                         </Button>
-                                                        <Button className="w-auto" variant="secondary" onClick={() => moveSlide(s.id, 1)} title="Descer">
+                                                        <Button
+                                                            className="w-auto"
+                                                            variant="secondary"
+                                                            onClick={() => moveSlide(s.id, 1)}
+                                                            title="Descer"
+                                                        >
                                                             ↓
                                                         </Button>
                                                         <Button
@@ -667,7 +678,12 @@ export default function Painel() {
                                                         >
                                                             {s.is_published ? 'Publicado' : 'Rascunho'}
                                                         </Button>
-                                                        <Button className="w-auto" variant="destructive" onClick={() => deleteSlide(s.id)} title="Excluir">
+                                                        <Button
+                                                            className="w-auto"
+                                                            variant="destructive"
+                                                            onClick={() => deleteSlide(s.id)}
+                                                            title="Excluir"
+                                                        >
                                                             Excluir
                                                         </Button>
                                                     </div>
@@ -751,10 +767,14 @@ export default function Painel() {
                                                     </DialogContent>
                                                 </Dialog>
                                                 {newFeatured.image_id && (
-                                                    <img
-                                                        src={images.find((i) => i.id === newFeatured.image_id)?.url}
-                                                        alt="Selecionada"
-                                                        className="h-10 w-14 rounded object-cover"
+                                                    <ImagePreview
+                                                        src={images.find((i) => i.id === newFeatured.image_id)?.url ?? ''}
+                                                        titulo={newFeatured.title}
+                                                        preco={newFeatured.price}
+                                                        quartos={newFeatured.bedrooms}
+                                                        banheiros={newFeatured.bathrooms}
+                                                        area={newFeatured.area}
+                                                        bairro={newFeatured.neighborhood}
                                                     />
                                                 )}
                                             </div>
@@ -903,12 +923,7 @@ export default function Painel() {
                                         )}
                                     </div>
                                     <div className="flex items-end gap-2">
-                                        <Button
-                                            className="w-auto"
-                                            onClick={submitFeatured}
-                                            disabled={creatingFeatured}
-                                            title="Adicionar Destaque"
-                                        >
+                                        <Button className="w-auto" onClick={submitFeatured} disabled={creatingFeatured} title="Adicionar Destaque">
                                             {creatingFeatured ? '…' : '+'}
                                         </Button>
                                     </div>
@@ -928,10 +943,20 @@ export default function Painel() {
                                                         <div className="text-xs text-muted-foreground">{f.price}</div>
                                                     </div>
                                                     <div className="flex shrink-0 items-center gap-1">
-                                                        <Button className="w-auto" variant="secondary" onClick={() => moveFeatured(f.id, -1)} title="Subir">
+                                                        <Button
+                                                            className="w-auto"
+                                                            variant="secondary"
+                                                            onClick={() => moveFeatured(f.id, -1)}
+                                                            title="Subir"
+                                                        >
                                                             ↑
                                                         </Button>
-                                                        <Button className="w-auto" variant="secondary" onClick={() => moveFeatured(f.id, 1)} title="Descer">
+                                                        <Button
+                                                            className="w-auto"
+                                                            variant="secondary"
+                                                            onClick={() => moveFeatured(f.id, 1)}
+                                                            title="Descer"
+                                                        >
                                                             ↓
                                                         </Button>
                                                         <Button
@@ -942,7 +967,12 @@ export default function Painel() {
                                                         >
                                                             {f.is_published ? 'Publicado' : 'Rascunho'}
                                                         </Button>
-                                                        <Button className="w-auto" variant="destructive" onClick={() => deleteFeatured(f.id)} title="Excluir">
+                                                        <Button
+                                                            className="w-auto"
+                                                            variant="destructive"
+                                                            onClick={() => deleteFeatured(f.id)}
+                                                            title="Excluir"
+                                                        >
                                                             Excluir
                                                         </Button>
                                                     </div>


### PR DESCRIPTION
## Summary
- add ImagePreview component with overlay and zoom controls
- use ImagePreview for slide and featured property previews in painel

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 22 errors)
- `npm run types` (fails: TS errors in routes/password/index.ts)


------
https://chatgpt.com/codex/tasks/task_b_68c0b9e76e88832c8eac25e0a728e3b1