### PR TITLE
refactor: align image preview with hero slide layout

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { MapPin, Bed, Bath, Square } from 'lucide-react';
+import { Icon } from './icon';
 
 interface ImagePreviewProps {
     src: string;
@@ -18,40 +20,58 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
     const zoomOut = () => setZoom((z) => Math.max(z - 0.25, 0.5));
 
     return (
-        <div className="relative inline-block">
-            <div className="h-40 w-64 overflow-hidden rounded-md">
-                <img
-                    src={src}
-                    alt={titulo ?? ''}
-                    className="h-full w-full object-cover transition-transform"
-                    style={{ transform: `scale(${zoom})` }}
-                />
-                <div className="absolute inset-0 bg-black/40" />
-                <div className="absolute inset-0 flex flex-col justify-between p-4 text-white">
-                    <div>
-                        {bairro && <span className="rounded bg-black/50 px-2 py-1 text-xs">{bairro}</span>}
-                        {titulo && <h3 className="mt-2 text-lg leading-tight font-bold">{titulo}</h3>}
-                        {subtitulo && <p className="text-sm">{subtitulo}</p>}
-                    </div>
-                    <div>
-                        {preco && <div className="text-xl font-bold">{preco}</div>}
-                        {(quartos || banheiros || area) && (
-                            <div className="mt-1 flex gap-2 text-xs">
-                                {quartos && <span>{quartos}q</span>}
-                                {banheiros && <span>{banheiros}b</span>}
-                                {area && <span>{area}</span>}
-                            </div>
-                        )}
+        <div className="relative w-full overflow-hidden rounded-md aspect-video">
+            <img
+                src={src}
+                alt={titulo ?? ''}
+                className="h-full w-full object-cover transition-transform"
+                style={{ transform: `scale(${zoom})` }}
+            />
+            <div className="absolute inset-0 hero-overlay" />
+            <div className="absolute inset-0 flex flex-col justify-between p-4 text-white">
+                <div className="flex justify-between">
+                    {bairro && (
+                        <span className="inline-flex items-center px-2 py-1 bg-primary/20 backdrop-blur-sm rounded-full text-xs font-medium text-primary-foreground">
+                            <Icon iconNode={MapPin} size={12} className="mr-1" />
+                            {bairro}
+                        </span>
+                    )}
+                    <div className="flex gap-1">
+                        <button type="button" onClick={zoomOut} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
+                            -
+                        </button>
+                        <button type="button" onClick={zoomIn} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
+                            +
+                        </button>
                     </div>
                 </div>
-            </div>
-            <div className="absolute right-2 bottom-2 flex gap-1">
-                <button type="button" onClick={zoomOut} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
-                    -
-                </button>
-                <button type="button" onClick={zoomIn} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
-                    +
-                </button>
+                <div>
+                    {titulo && <h3 className="text-lg font-bold leading-tight text-shadow">{titulo}</h3>}
+                    {subtitulo && <p className="text-sm text-gray-100 text-shadow">{subtitulo}</p>}
+                    {(quartos || banheiros || area) && (
+                        <div className="mt-4 flex flex-wrap items-center gap-2">
+                            {quartos && (
+                                <div className="flex items-center space-x-1 bg-white/15 backdrop-blur-sm rounded px-2 py-1 border border-white/10">
+                                    <Icon iconNode={Bed} size={12} color="white" />
+                                    <span className="text-xs font-semibold">{quartos} quartos</span>
+                                </div>
+                            )}
+                            {banheiros && (
+                                <div className="flex items-center space-x-1 bg-white/15 backdrop-blur-sm rounded px-2 py-1 border border-white/10">
+                                    <Icon iconNode={Bath} size={12} color="white" />
+                                    <span className="text-xs font-semibold">{banheiros} banheiros</span>
+                                </div>
+                            )}
+                            {area && (
+                                <div className="flex items-center space-x-1 bg-white/15 backdrop-blur-sm rounded px-2 py-1 border border-white/10">
+                                    <Icon iconNode={Square} size={12} color="white" />
+                                    <span className="text-xs font-semibold">{area}</span>
+                                </div>
+                            )}
+                        </div>
+                    )}
+                    {preco && <div className="mt-4 text-xl font-bold text-primary text-shadow">{preco}</div>}
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- expand ImagePreview to full-width 16:9 container
- mirror HeroCarousel slide structure with location badge, metadata, and price
- relocate zoom controls away from text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 22 problems in unrelated files)*
- `npx eslint resources/js/components/ImagePreview.tsx`
- `npm run types` *(fails: TS2395, TS2440 in resources/js/routes/password/index.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68c0cb1a66d0832cb381efb63cf11e9a