### PR TITLE
Align image preview overlay with hero layout

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -1,6 +1,7 @@
+import { Bath, Bed, MapPin, MessageCircle, Phone, Square } from 'lucide-react';
 import { useState } from 'react';
-import { MapPin, Bed, Bath, Square } from 'lucide-react';
 import { Icon } from './icon';
+import { Button } from './ui/button';
 
 interface ImagePreviewProps {
     src: string;
@@ -19,59 +20,89 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
     const zoomIn = () => setZoom((z) => Math.min(z + 0.25, 3));
     const zoomOut = () => setZoom((z) => Math.max(z - 0.25, 0.5));
 
+    const handleWhatsAppClick = () => {
+        const message = encodeURIComponent(`Olá! Tenho interesse no imóvel: ${titulo ?? ''} - ${preco ?? ''}. Gostaria de mais informações.`);
+        window.open(`https://wa.me/5562999999999?text=${message}`, '_blank');
+    };
+
     return (
-        <div className="relative w-full overflow-hidden rounded-md aspect-video">
-            <img
-                src={src}
-                alt={titulo ?? ''}
-                className="h-full w-full object-cover transition-transform"
-                style={{ transform: `scale(${zoom})` }}
-            />
-            <div className="absolute inset-0 hero-overlay" />
-            <div className="absolute inset-0 flex flex-col justify-between p-4 text-white">
-                <div className="flex justify-between">
-                    {bairro && (
-                        <span className="inline-flex items-center px-2 py-1 bg-primary/20 backdrop-blur-sm rounded-full text-xs font-medium text-primary-foreground">
-                            <Icon iconNode={MapPin} size={12} className="mr-1" />
-                            {bairro}
-                        </span>
-                    )}
-                    <div className="flex gap-1">
-                        <button type="button" onClick={zoomOut} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
-                            -
-                        </button>
-                        <button type="button" onClick={zoomIn} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
-                            +
-                        </button>
+        <div className="relative aspect-video w-full overflow-hidden rounded-md">
+            <img src={src} alt={titulo ?? ''} className="h-full w-full object-cover transition-transform" style={{ transform: `scale(${zoom})` }} />
+            <div className="hero-overlay absolute inset-0" />
+
+            <div className="absolute inset-0 flex items-center">
+                <div className="container-responsive">
+                    <div className="max-w-3xl text-white">
+                        {bairro && (
+                            <div className="mb-4">
+                                <span className="inline-flex items-center rounded-full bg-primary/20 px-4 py-2 text-sm font-medium text-primary-foreground backdrop-blur-sm">
+                                    <Icon iconNode={MapPin} size={16} className="mr-2" />
+                                    {bairro}
+                                </span>
+                            </div>
+                        )}
+
+                        {titulo && (
+                            <h1 className="text-shadow mb-6 text-4xl leading-tight font-bold text-balance sm:text-5xl lg:text-6xl">{titulo}</h1>
+                        )}
+
+                        {subtitulo && <p className="text-shadow mb-8 max-w-2xl text-xl text-gray-100 sm:text-2xl">{subtitulo}</p>}
+
+                        {(quartos || banheiros || area) && (
+                            <div className="mb-10 flex flex-wrap items-center gap-4">
+                                {quartos && (
+                                    <div className="flex items-center space-x-2 rounded-xl border border-white/10 bg-white/15 px-4 py-3 backdrop-blur-sm">
+                                        <Icon iconNode={Bed} size={20} color="white" />
+                                        <span className="text-sm font-semibold">{quartos} quartos</span>
+                                    </div>
+                                )}
+                                {banheiros && (
+                                    <div className="flex items-center space-x-2 rounded-xl border border-white/10 bg-white/15 px-4 py-3 backdrop-blur-sm">
+                                        <Icon iconNode={Bath} size={20} color="white" />
+                                        <span className="text-sm font-semibold">{banheiros} banheiros</span>
+                                    </div>
+                                )}
+                                {area && (
+                                    <div className="flex items-center space-x-2 rounded-xl border border-white/10 bg-white/15 px-4 py-3 backdrop-blur-sm">
+                                        <Icon iconNode={Square} size={20} color="white" />
+                                        <span className="text-sm font-semibold">{area}</span>
+                                    </div>
+                                )}
+                            </div>
+                        )}
+
+                        <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center">
+                            {preco && <div className="text-3xl font-bold text-primary sm:text-4xl lg:text-5xl">{preco}</div>}
+                            <div className="flex flex-wrap gap-4">
+                                <Button
+                                    variant="default"
+                                    onClick={handleWhatsAppClick}
+                                    className="bg-accent px-6 py-3 text-base font-semibold text-white shadow-lg transition-all duration-200 hover:bg-accent/90 hover:shadow-xl"
+                                >
+                                    <Icon iconNode={MessageCircle} size={16} className="mr-2" />
+                                    Ver Detalhes
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    onClick={() => window.open('tel:+5562999999999')}
+                                    className="border-2 border-white px-6 py-3 text-base font-semibold text-white backdrop-blur-sm transition-all duration-200 hover:bg-white hover:text-gray-900"
+                                >
+                                    <Icon iconNode={Phone} size={16} className="mr-2" />
+                                    Ligar Agora
+                                </Button>
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <div>
-                    {titulo && <h3 className="text-lg font-bold leading-tight text-shadow">{titulo}</h3>}
-                    {subtitulo && <p className="text-sm text-gray-100 text-shadow">{subtitulo}</p>}
-                    {(quartos || banheiros || area) && (
-                        <div className="mt-4 flex flex-wrap items-center gap-2">
-                            {quartos && (
-                                <div className="flex items-center space-x-1 bg-white/15 backdrop-blur-sm rounded px-2 py-1 border border-white/10">
-                                    <Icon iconNode={Bed} size={12} color="white" />
-                                    <span className="text-xs font-semibold">{quartos} quartos</span>
-                                </div>
-                            )}
-                            {banheiros && (
-                                <div className="flex items-center space-x-1 bg-white/15 backdrop-blur-sm rounded px-2 py-1 border border-white/10">
-                                    <Icon iconNode={Bath} size={12} color="white" />
-                                    <span className="text-xs font-semibold">{banheiros} banheiros</span>
-                                </div>
-                            )}
-                            {area && (
-                                <div className="flex items-center space-x-1 bg-white/15 backdrop-blur-sm rounded px-2 py-1 border border-white/10">
-                                    <Icon iconNode={Square} size={12} color="white" />
-                                    <span className="text-xs font-semibold">{area}</span>
-                                </div>
-                            )}
-                        </div>
-                    )}
-                    {preco && <div className="mt-4 text-xl font-bold text-primary text-shadow">{preco}</div>}
-                </div>
+            </div>
+
+            <div className="absolute top-4 right-4 flex gap-1">
+                <button type="button" onClick={zoomOut} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
+                    -
+                </button>
+                <button type="button" onClick={zoomIn} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
+                    +
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- Refactor image preview markup to mirror HeroCarousel layout
- Add action buttons and centralize badges and property info
- Move zoom controls to top-right for cleaner overlay

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden...)*
- `npm run types` *(fails: Import declaration conflicts with local declaration of 'confirm')*

------
https://chatgpt.com/codex/tasks/task_b_68c0d040ed20832cbfff3f72d199c154