### PR TITLE
fix: remove hero overlay dependency

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -28,14 +28,14 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
     return (
         <div className="relative aspect-video w-full overflow-hidden rounded-md">
             <img src={src} alt={titulo ?? ''} className="h-full w-full object-cover transition-transform" style={{ transform: `scale(${zoom})` }} />
-            <div className="hero-overlay absolute inset-0" />
+            <div className="absolute inset-0 bg-gradient-to-tr from-black/40 via-black/20 to-black/10" />
 
             <div className="absolute inset-0 flex items-center">
                 <div className="container-responsive">
                     <div className="mx-auto text-center text-white">
                         {bairro && (
                             <div className="mb-4 flex justify-center">
-                                <span className="inline-flex items-center rounded-full bg-primary/20 px-4 py-2 text-sm font-medium text-primary-foreground backdrop-blur-sm">
+                                <span className="inline-flex items-center rounded-full bg-white/15 px-4 py-2 text-sm font-medium text-white backdrop-blur-sm">
                                     <Icon iconNode={MapPin} size={16} className="mr-2" />
                                     {bairro}
                                 </span>
@@ -72,7 +72,7 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
                         )}
 
                         <div className="flex flex-col items-center gap-6 sm:flex-row sm:items-center">
-                            {preco && <div className="text-3xl font-bold text-primary sm:text-4xl lg:text-5xl">{preco}</div>}
+                            {preco && <div className="text-3xl font-bold text-green-500 sm:text-4xl lg:text-5xl">{preco}</div>}
                             <div className="flex flex-wrap justify-center gap-4">
                                 <Button
                                     variant="default"


### PR DESCRIPTION
## Summary
- replace global `hero-overlay` with inline gradient
- use explicit color classes for badges and price

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden @typescript-eslint/no-require-imports...)*
- `npx eslint resources/js/components/ImagePreview.tsx`
- `npm run types` *(fails: TS2395: Individual declarations in merged declaration 'confirm' must be all exported or all local.)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c0d576f0d4832c91b406e6fe2b538a