### PR TITLE
Refine slide previews and streamline image selection

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -14,28 +14,44 @@ interface ImagePreviewProps {
     bairro?: string | null;
 }
 
-export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, banheiros, area, bairro }: ImagePreviewProps) {
+export default function ImagePreview({
+    src,
+    titulo,
+    subtitulo,
+    preco,
+    quartos,
+    banheiros,
+    area,
+    bairro,
+}: ImagePreviewProps) {
     const [zoom, setZoom] = useState(1);
 
     const zoomIn = () => setZoom((z) => Math.min(z + 0.25, 3));
     const zoomOut = () => setZoom((z) => Math.max(z - 0.25, 0.5));
 
     const handleWhatsAppClick = () => {
-        const message = encodeURIComponent(`Olá! Tenho interesse no imóvel: ${titulo ?? ''} - ${preco ?? ''}. Gostaria de mais informações.`);
+        const message = encodeURIComponent(
+            `Olá! Tenho interesse no imóvel: ${titulo ?? ''} - ${preco ?? ''}. Gostaria de mais informações.`,
+        );
         window.open(`https://wa.me/5562999999999?text=${message}`, '_blank');
     };
 
     return (
         <div className="relative aspect-video w-full overflow-hidden rounded-md">
-            <img src={src} alt={titulo ?? ''} className="h-full w-full object-cover transition-transform" style={{ transform: `scale(${zoom})` }} />
-            <div className="absolute inset-0 bg-gradient-to-tr from-black/40 via-black/20 to-black/10" />
+            <img
+                src={src}
+                alt={titulo ?? ''}
+                className="h-full w-full object-cover transition-transform"
+                style={{ transform: `scale(${zoom})` }}
+            />
+            <div className="absolute inset-0 hero-overlay" />
 
             <div className="absolute inset-0 flex items-center">
                 <div className="container-responsive">
-                    <div className="mx-auto text-center text-white">
+                    <div className="max-w-3xl text-white animate-fade-in-up">
                         {bairro && (
-                            <div className="mb-4 flex justify-center">
-                                <span className="inline-flex items-center rounded-full bg-white/15 px-4 py-2 text-sm font-medium text-white backdrop-blur-sm">
+                            <div className="mb-4">
+                                <span className="inline-flex items-center px-4 py-2 bg-primary/20 backdrop-blur-sm rounded-full text-sm font-medium text-primary-foreground">
                                     <Icon iconNode={MapPin} size={16} className="mr-2" />
                                     {bairro}
                                 </span>
@@ -43,27 +59,31 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
                         )}
 
                         {titulo && (
-                            <h1 className="text-shadow mb-6 text-2xl leading-tight font-bold text-balance sm:text-3xl lg:text-4xl">{titulo}</h1>
+                            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold mb-6 text-balance text-shadow leading-tight">
+                                {titulo}
+                            </h1>
                         )}
 
-                        {subtitulo && <p className="text-shadow mx-auto mb-8 max-w-2xl text-xl text-gray-100 sm:text-2xl">{subtitulo}</p>}
+                        {subtitulo && (
+                            <p className="text-xl sm:text-2xl mb-8 text-gray-100 text-shadow max-w-2xl">{subtitulo}</p>
+                        )}
 
                         {(quartos || banheiros || area) && (
-                            <div className="mb-10 flex flex-wrap items-center gap-4">
+                            <div className="flex flex-wrap items-center gap-4 mb-10">
                                 {quartos && (
-                                    <div className="flex items-center space-x-2 rounded-xl border border-white/10 bg-white/15 px-4 py-3 backdrop-blur-sm">
+                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
                                         <Icon iconNode={Bed} size={20} color="white" />
                                         <span className="text-sm font-semibold">{quartos} quartos</span>
                                     </div>
                                 )}
                                 {banheiros && (
-                                    <div className="flex items-center space-x-2 rounded-xl border border-white/10 bg-white/15 px-4 py-3 backdrop-blur-sm">
+                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
                                         <Icon iconNode={Bath} size={20} color="white" />
                                         <span className="text-sm font-semibold">{banheiros} banheiros</span>
                                     </div>
                                 )}
                                 {area && (
-                                    <div className="flex items-center space-x-2 rounded-xl border border-white/10 bg-white/15 px-4 py-3 backdrop-blur-sm">
+                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
                                         <Icon iconNode={Square} size={20} color="white" />
                                         <span className="text-sm font-semibold">{area}</span>
                                     </div>
@@ -71,24 +91,26 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
                             </div>
                         )}
 
-                        <div className="flex flex-col items-center gap-6 sm:flex-row sm:items-center">
-                            {preco && <div className="text-3xl font-bold text-green-500 sm:text-4xl lg:text-5xl">{preco}</div>}
-                            <div className="flex flex-wrap justify-center gap-4">
+                        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6">
+                            {preco && (
+                                <div className="text-3xl sm:text-4xl lg:text-5xl font-bold text-primary">{preco}</div>
+                            )}
+                            <div className="flex flex-wrap gap-4">
                                 <Button
                                     variant="default"
                                     onClick={handleWhatsAppClick}
-                                    className="bg-accent px-6 py-3 text-base font-semibold text-white shadow-lg transition-all duration-200 hover:bg-accent/90 hover:shadow-xl"
+                                    className="bg-accent hover:bg-accent/90 text-white font-semibold px-6 py-3 text-base shadow-lg hover:shadow-xl transition-all duration-200"
                                 >
                                     <Icon iconNode={MessageCircle} size={16} className="mr-2" />
-                                    Ver Detalhes
+                                    Detalhes
                                 </Button>
                                 <Button
                                     variant="outline"
                                     onClick={() => window.open('tel:+5562999999999')}
-                                    className="border-2 border-white px-6 py-3 text-base font-semibold text-white backdrop-blur-sm transition-all duration-200 hover:bg-white hover:text-gray-900"
+                                    className="border-2 border-white text-white hover:bg-white hover:text-gray-900 font-semibold px-6 py-3 text-base backdrop-blur-sm transition-all duration-200"
                                 >
                                     <Icon iconNode={Phone} size={16} className="mr-2" />
-                                    Ligar Agora
+                                    Ligar
                                 </Button>
                             </div>
                         </div>
@@ -97,13 +119,22 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
             </div>
 
             <div className="absolute top-4 right-4 flex gap-1">
-                <button type="button" onClick={zoomOut} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
+                <button
+                    type="button"
+                    onClick={zoomOut}
+                    className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white"
+                >
                     -
                 </button>
-                <button type="button" onClick={zoomIn} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
+                <button
+                    type="button"
+                    onClick={zoomIn}
+                    className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white"
+                >
                     +
                 </button>
             </div>
         </div>
     );
 }
+

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
@@ -165,7 +165,7 @@ const HeroCarousel = () => {
                           onClick={() => handleWhatsAppClick(property)}
                           className="bg-accent hover:bg-accent/90 text-white font-semibold px-6 py-3 text-base shadow-lg hover:shadow-xl transition-all duration-200"
                         >
-                          Ver Detalhes
+                          Detalhes
                         </Button>
                         <Button
                           variant="outline"
@@ -174,7 +174,7 @@ const HeroCarousel = () => {
                           onClick={() => window.open('tel:+5562999999999')}
                           className="border-2 border-white text-white hover:bg-white hover:text-gray-900 font-semibold px-6 py-3 text-base backdrop-blur-sm transition-all duration-200"
                         >
-                          Ligar Agora
+                          Ligar
                         </Button>
                       </div>
                     </div>

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
 import HeaderStandalone from '@/main/components/ui/HeaderStandalone';
 import type { BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
@@ -594,7 +595,7 @@ export default function Painel() {
                                                             setImagePickerOpen(true);
                                                         }}
                                                     >
-                                                        Selecionar da galeria
+                                                        Galeria
                                                     </Button>
                                                 </DialogTrigger>
                                                 <DialogContent className="sm:max-w-3xl">
@@ -620,7 +621,12 @@ export default function Painel() {
                                                 </DialogContent>
                                             </Dialog>
                                         </div>
-                                        <div className="mt-4 aspect-video w-full border-2 border-dashed">
+                                        <div
+                                            className={cn(
+                                                'mt-4 aspect-video w-full overflow-hidden',
+                                                !newSlide.image_id && 'border-2 border-dashed',
+                                            )}
+                                        >
                                             {newSlide.image_id && (
                                                 <ImagePreview
                                                     src={images.find((i) => i.id === newSlide.image_id)?.url ?? ''}
@@ -722,65 +728,7 @@ export default function Painel() {
                                     </div>
                                 </DialogHeader>
                                 <div className="space-y-4">
-                                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-                                        <div>
-                                            <Label>Imagem</Label>
-                                            <div className="mt-2 flex items-center gap-2">
-                                                <Dialog
-                                                    open={imagePickerOpen && imagePickerFor === 'featured'}
-                                                    onOpenChange={(o) => {
-                                                        setImagePickerOpen(o);
-                                                        if (!o) setImagePickerFor(null);
-                                                    }}
-                                                >
-                                                    <DialogTrigger asChild>
-                                                        <Button
-                                                            type="button"
-                                                            variant="secondary"
-                                                            className="w-auto"
-                                                            onClick={() => {
-                                                                setImagePickerFor('featured');
-                                                                setImagePickerOpen(true);
-                                                            }}
-                                                        >
-                                                            Galeria
-                                                        </Button>
-                                                    </DialogTrigger>
-                                                    <DialogContent className="sm:max-w-3xl">
-                                                        <DialogHeader>
-                                                            <DialogTitle>Escolher imagem</DialogTitle>
-                                                        </DialogHeader>
-                                                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
-                                                            {images.map((img) => (
-                                                                <button
-                                                                    key={img.id}
-                                                                    type="button"
-                                                                    className="overflow-hidden rounded-md border focus:ring-2 focus:ring-ring focus:outline-none"
-                                                                    onClick={() => {
-                                                                        setNewFeatured((s) => ({ ...s, image_id: img.id }));
-                                                                        setImagePickerOpen(false);
-                                                                        setImagePickerFor(null);
-                                                                    }}
-                                                                >
-                                                                    <img src={img.url} alt={img.original_name} className="h-28 w-full object-cover" />
-                                                                </button>
-                                                            ))}
-                                                        </div>
-                                                    </DialogContent>
-                                                </Dialog>
-                                                {newFeatured.image_id && (
-                                                    <ImagePreview
-                                                        src={images.find((i) => i.id === newFeatured.image_id)?.url ?? ''}
-                                                        titulo={newFeatured.title}
-                                                        preco={newFeatured.price}
-                                                        quartos={newFeatured.bedrooms}
-                                                        banheiros={newFeatured.bathrooms}
-                                                        area={newFeatured.area}
-                                                        bairro={newFeatured.neighborhood}
-                                                    />
-                                                )}
-                                            </div>
-                                        </div>
+                                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                                         <div>
                                             <Label>Título</Label>
                                             <Input
@@ -926,7 +874,7 @@ export default function Painel() {
                                     </div>
                                     <div>
                                         <Label>Imagem</Label>
-                                        <div className="mt-2 flex items-center gap-2">
+                                        <div className="mt-2">
                                             <Dialog
                                                 open={imagePickerOpen && imagePickerFor === 'featured'}
                                                 onOpenChange={(o) => {
@@ -944,7 +892,7 @@ export default function Painel() {
                                                             setImagePickerOpen(true);
                                                         }}
                                                     >
-                                                        Selecionar da galeria
+                                                        Galeria
                                                     </Button>
                                                 </DialogTrigger>
                                                 <DialogContent className="sm:max-w-3xl">
@@ -969,11 +917,22 @@ export default function Painel() {
                                                     </div>
                                                 </DialogContent>
                                             </Dialog>
+                                        </div>
+                                        <div
+                                            className={cn(
+                                                'mt-4 aspect-video w-full overflow-hidden',
+                                                !newFeatured.image_id && 'border-2 border-dashed',
+                                            )}
+                                        >
                                             {newFeatured.image_id && (
-                                                <img
-                                                    src={images.find((i) => i.id === newFeatured.image_id)?.url}
-                                                    alt="Selecionada"
-                                                    className="h-10 w-14 rounded object-cover"
+                                                <ImagePreview
+                                                    src={images.find((i) => i.id === newFeatured.image_id)?.url ?? ''}
+                                                    titulo={newFeatured.title}
+                                                    preco={newFeatured.price}
+                                                    quartos={newFeatured.bedrooms}
+                                                    banheiros={newFeatured.bathrooms}
+                                                    area={newFeatured.area}
+                                                    bairro={newFeatured.neighborhood}
                                                 />
                                             )}
                                         </div>


### PR DESCRIPTION
## Summary
- Align image preview component with hero slide design and add concise action buttons
- Shorten admin panel labels and show large preview after choosing an image
- Move image pickers to the end with dashed placeholders and zoomable previews

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-require-imports, react-hooks/rules-of-hooks, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68c0a905c3f0832ca48f7874046ba7b9