### PR TITLE
Adjust preview to mirror hero layout

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -44,72 +44,72 @@ export default function ImagePreview({
                 className="h-full w-full object-cover transition-transform"
                 style={{ transform: `scale(${zoom})` }}
             />
-            <div className="absolute inset-0 hero-overlay" />
+            <div className="absolute inset-0 bg-gradient-to-tr from-black/60 via-black/30 to-black/10" />
 
             <div className="absolute inset-0 flex items-center">
                 <div className="container-responsive">
-                    <div className="max-w-3xl text-white animate-fade-in-up">
+                    <div className="max-w-3xl mx-auto text-white animate-fade-in-up">
                         {bairro && (
                             <div className="mb-4">
-                                <span className="inline-flex items-center px-4 py-2 bg-primary/20 backdrop-blur-sm rounded-full text-sm font-medium text-primary-foreground">
-                                    <Icon iconNode={MapPin} size={16} className="mr-2" />
+                                <span className="inline-flex items-center px-3 py-1.5 bg-primary/20 backdrop-blur-sm rounded-full text-xs sm:text-sm font-medium text-primary-foreground">
+                                    <Icon iconNode={MapPin} size={14} className="mr-2" />
                                     {bairro}
                                 </span>
                             </div>
                         )}
 
                         {titulo && (
-                            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold mb-6 text-balance text-shadow leading-tight">
+                            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 text-balance text-shadow leading-tight">
                                 {titulo}
                             </h1>
                         )}
 
                         {subtitulo && (
-                            <p className="text-xl sm:text-2xl mb-8 text-gray-100 text-shadow max-w-2xl">{subtitulo}</p>
+                            <p className="text-base sm:text-lg mb-6 text-gray-100 text-shadow max-w-2xl">{subtitulo}</p>
                         )}
 
                         {(quartos || banheiros || area) && (
-                            <div className="flex flex-wrap items-center gap-4 mb-10">
+                            <div className="flex flex-wrap items-center gap-3 mb-6">
                                 {quartos && (
-                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
-                                        <Icon iconNode={Bed} size={20} color="white" />
-                                        <span className="text-sm font-semibold">{quartos} quartos</span>
+                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-3 py-2 border border-white/10">
+                                        <Icon iconNode={Bed} size={16} color="white" />
+                                        <span className="text-xs sm:text-sm font-semibold">{quartos} quartos</span>
                                     </div>
                                 )}
                                 {banheiros && (
-                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
-                                        <Icon iconNode={Bath} size={20} color="white" />
-                                        <span className="text-sm font-semibold">{banheiros} banheiros</span>
+                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-3 py-2 border border-white/10">
+                                        <Icon iconNode={Bath} size={16} color="white" />
+                                        <span className="text-xs sm:text-sm font-semibold">{banheiros} banheiros</span>
                                     </div>
                                 )}
                                 {area && (
-                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
-                                        <Icon iconNode={Square} size={20} color="white" />
-                                        <span className="text-sm font-semibold">{area}</span>
+                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-3 py-2 border border-white/10">
+                                        <Icon iconNode={Square} size={16} color="white" />
+                                        <span className="text-xs sm:text-sm font-semibold">{area}</span>
                                     </div>
                                 )}
                             </div>
                         )}
 
-                        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6">
+                        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6">
                             {preco && (
-                                <div className="text-3xl sm:text-4xl lg:text-5xl font-bold text-primary">{preco}</div>
+                                <div className="text-2xl sm:text-3xl lg:text-4xl font-bold text-primary">{preco}</div>
                             )}
-                            <div className="flex flex-wrap gap-4">
+                            <div className="flex flex-wrap gap-3 sm:gap-4">
                                 <Button
                                     variant="default"
                                     onClick={handleWhatsAppClick}
-                                    className="bg-accent hover:bg-accent/90 text-white font-semibold px-6 py-3 text-base shadow-lg hover:shadow-xl transition-all duration-200"
+                                    className="bg-accent hover:bg-accent/90 text-white font-semibold px-5 py-2.5 text-sm sm:text-base shadow-lg hover:shadow-xl transition-all duration-200"
                                 >
-                                    <Icon iconNode={MessageCircle} size={16} className="mr-2" />
+                                    <Icon iconNode={MessageCircle} size={14} className="mr-2" />
                                     Detalhes
                                 </Button>
                                 <Button
                                     variant="outline"
                                     onClick={() => window.open('tel:+5562999999999')}
-                                    className="border-2 border-white text-white hover:bg-white hover:text-gray-900 font-semibold px-6 py-3 text-base backdrop-blur-sm transition-all duration-200"
+                                    className="border-2 border-white text-white hover:bg-white hover:text-gray-900 font-semibold px-5 py-2.5 text-sm sm:text-base backdrop-blur-sm transition-all duration-200"
                                 >
-                                    <Icon iconNode={Phone} size={16} className="mr-2" />
+                                    <Icon iconNode={Phone} size={14} className="mr-2" />
                                     Ligar
                                 </Button>
                             </div>


### PR DESCRIPTION
## Summary
- match preview layout to hero using gradient overlay and centered container
- scale typography, spacing, and icon sizes for clearer modal preview

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 22 errors)
- `npm run format:check` (fails: Code style issues found in 84 files)
- `npm run types` (fails: Import declaration conflicts)


------
https://chatgpt.com/codex/tasks/task_b_68c0defe04a0832cbb54ceeb54718526