### PR TITLE
Refatora pré-visualização da hero para espelhar slide real

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -1,7 +1,5 @@
-import { Bath, Bed, MapPin, MessageCircle, Phone, Square } from 'lucide-react';
 import { useState } from 'react';
-import { Icon } from './icon';
-import { Button } from './ui/button';
+import HeroSlide from '@/main/pages/homepage-premium-real-estate-consultancy/components/HeroSlide';
 
 interface ImagePreviewProps {
     src: string;
@@ -38,84 +36,22 @@ export default function ImagePreview({
 
     return (
         <div className="relative aspect-video w-full overflow-hidden rounded-md">
-            <img
-                src={src}
-                alt={titulo ?? ''}
-                className="h-full w-full object-cover transition-transform"
-                style={{ transform: `scale(${zoom})` }}
-            />
-            <div className="absolute inset-0 bg-gradient-to-tr from-black/60 via-black/30 to-black/10" />
-
-            <div className="absolute inset-0 flex items-center">
-                <div className="container-responsive">
-                    <div className="max-w-3xl mx-auto text-white animate-fade-in-up">
-                        {bairro && (
-                            <div className="mb-4">
-                                <span className="inline-flex items-center px-3 py-1.5 bg-primary/20 backdrop-blur-sm rounded-full text-xs sm:text-sm font-medium text-primary-foreground">
-                                    <Icon iconNode={MapPin} size={14} className="mr-2" />
-                                    {bairro}
-                                </span>
-                            </div>
-                        )}
-
-                        {titulo && (
-                            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4 text-balance text-shadow leading-tight">
-                                {titulo}
-                            </h1>
-                        )}
-
-                        {subtitulo && (
-                            <p className="text-base sm:text-lg mb-6 text-gray-100 text-shadow max-w-2xl">{subtitulo}</p>
-                        )}
-
-                        {(quartos || banheiros || area) && (
-                            <div className="flex flex-wrap items-center gap-3 mb-6">
-                                {quartos && (
-                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-3 py-2 border border-white/10">
-                                        <Icon iconNode={Bed} size={16} color="white" />
-                                        <span className="text-xs sm:text-sm font-semibold">{quartos} quartos</span>
-                                    </div>
-                                )}
-                                {banheiros && (
-                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-3 py-2 border border-white/10">
-                                        <Icon iconNode={Bath} size={16} color="white" />
-                                        <span className="text-xs sm:text-sm font-semibold">{banheiros} banheiros</span>
-                                    </div>
-                                )}
-                                {area && (
-                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-3 py-2 border border-white/10">
-                                        <Icon iconNode={Square} size={16} color="white" />
-                                        <span className="text-xs sm:text-sm font-semibold">{area}</span>
-                                    </div>
-                                )}
-                            </div>
-                        )}
-
-                        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6">
-                            {preco && (
-                                <div className="text-2xl sm:text-3xl lg:text-4xl font-bold text-primary">{preco}</div>
-                            )}
-                            <div className="flex flex-wrap gap-3 sm:gap-4">
-                                <Button
-                                    variant="default"
-                                    onClick={handleWhatsAppClick}
-                                    className="bg-accent hover:bg-accent/90 text-white font-semibold px-5 py-2.5 text-sm sm:text-base shadow-lg hover:shadow-xl transition-all duration-200"
-                                >
-                                    <Icon iconNode={MessageCircle} size={14} className="mr-2" />
-                                    Detalhes
-                                </Button>
-                                <Button
-                                    variant="outline"
-                                    onClick={() => window.open('tel:+5562999999999')}
-                                    className="border-2 border-white text-white hover:bg-white hover:text-gray-900 font-semibold px-5 py-2.5 text-sm sm:text-base backdrop-blur-sm transition-all duration-200"
-                                >
-                                    <Icon iconNode={Phone} size={14} className="mr-2" />
-                                    Ligar
-                                </Button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+            <div
+                className="h-full w-full transition-transform"
+                style={{ transform: `scale(${zoom})`, transformOrigin: 'center' }}
+            >
+                <HeroSlide
+                    image={src}
+                    title={titulo}
+                    subtitle={subtitulo}
+                    price={preco}
+                    bedrooms={quartos}
+                    bathrooms={banheiros}
+                    area={area}
+                    neighborhood={bairro}
+                    onWhatsAppClick={handleWhatsAppClick}
+                    onCallClick={() => window.open('tel:+5562999999999')}
+                />
             </div>
 
             <div className="absolute top-4 right-4 flex gap-1">

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Icon from '../../../components/AppIcon';
-import Image from '../../../components/AppImage';
-import Button from '../../../components/ui/Button';
+import HeroSlide from './HeroSlide';
 
 const HeroCarousel = () => {
   const [currentSlide, setCurrentSlide] = useState(0);
@@ -109,79 +108,18 @@ const HeroCarousel = () => {
               index === currentSlide ? 'opacity-100 scale-100' : 'opacity-0 scale-105'
             }`}
           >
-            <div className="relative w-full h-full">
-              <Image
-                src={property?.image}
-                alt={property?.title}
-                className="w-full h-full object-cover object-center"
-                loading={index === 0 ? 'eager' : 'lazy'}
-              />
-              <div className="absolute inset-0 hero-overlay" />
-
-              {/* Volta a posição anterior (centrado verticalmente) */}
-              <div className="absolute inset-0 flex items-center">
-                <div className="container-responsive">
-                  <div className="max-w-3xl text-white animate-fade-in-up">
-                    <div className="mb-4">
-                      <span className="inline-flex items-center px-4 py-2 bg-primary/20 backdrop-blur-sm rounded-full text-sm font-medium text-primary-foreground">
-                        <Icon name="MapPin" size={16} className="mr-2" />
-                        {property?.neighborhood}
-                      </span>
-                    </div>
-                    
-                    <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold mb-6 text-balance text-shadow leading-tight">
-                      {property?.title}
-                    </h1>
-                    
-                    <p className="text-xl sm:text-2xl mb-8 text-gray-100 text-shadow max-w-2xl">
-                      {property?.subtitle}
-                    </p>
-                    
-                    <div className="flex flex-wrap items-center gap-4 mb-10">
-                      <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
-                        <Icon name="Bed" size={20} color="white" />
-                        <span className="text-sm font-semibold">{property?.bedrooms} quartos</span>
-                      </div>
-                      <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
-                        <Icon name="Bath" size={20} color="white" />
-                        <span className="text-sm font-semibold">{property?.bathrooms} banheiros</span>
-                      </div>
-                      <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
-                        <Icon name="Square" size={20} color="white" />
-                        <span className="text-sm font-semibold">{property?.area}</span>
-                      </div>
-                    </div>
-                    
-                    <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6">
-                      {/* Preço sem contorno */}
-                      <div className="text-3xl sm:text-4xl lg:text-5xl font-bold text-primary">
-                        {property?.price}
-                      </div>
-                      <div className="flex flex-wrap gap-4">
-                        <Button
-                          variant="default"
-                          iconName="MessageCircle"
-                          iconPosition="left"
-                          onClick={() => handleWhatsAppClick(property)}
-                          className="bg-accent hover:bg-accent/90 text-white font-semibold px-6 py-3 text-base shadow-lg hover:shadow-xl transition-all duration-200"
-                        >
-                          Detalhes
-                        </Button>
-                        <Button
-                          variant="outline"
-                          iconName="Phone"
-                          iconPosition="left"
-                          onClick={() => window.open('tel:+5562999999999')}
-                          className="border-2 border-white text-white hover:bg-white hover:text-gray-900 font-semibold px-6 py-3 text-base backdrop-blur-sm transition-all duration-200"
-                        >
-                          Ligar
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <HeroSlide
+              image={property?.image}
+              title={property?.title}
+              subtitle={property?.subtitle}
+              price={property?.price}
+              bedrooms={property?.bedrooms}
+              bathrooms={property?.bathrooms}
+              area={property?.area}
+              neighborhood={property?.neighborhood}
+              onWhatsAppClick={() => handleWhatsAppClick(property)}
+              onCallClick={() => window.open('tel:+5562999999999')}
+            />
           </div>
         ))}
       </div>

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroSlide.tsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroSlide.tsx
@@ -1,0 +1,117 @@
+import Icon from '../../../components/AppIcon';
+import Image from '../../../components/AppImage';
+import Button from '../../../components/ui/Button';
+
+export interface HeroSlideProps {
+  image: string;
+  title?: string | null;
+  subtitle?: string | null;
+  price?: string | null;
+  bedrooms?: number | string | null;
+  bathrooms?: number | string | null;
+  area?: string | null;
+  neighborhood?: string | null;
+  onWhatsAppClick?: () => void;
+  onCallClick?: () => void;
+}
+
+const HeroSlide = ({
+  image,
+  title,
+  subtitle,
+  price,
+  bedrooms,
+  bathrooms,
+  area,
+  neighborhood,
+  onWhatsAppClick,
+  onCallClick,
+}: HeroSlideProps) => {
+  return (
+    <div className="relative w-full h-full">
+      <Image
+        src={image}
+        alt={title ?? ''}
+        className="w-full h-full object-cover object-center"
+        loading="lazy"
+      />
+      <div className="absolute inset-0 hero-overlay" />
+      <div className="absolute inset-0 flex items-center">
+        <div className="container-responsive">
+          <div className="max-w-3xl text-white animate-fade-in-up">
+            {neighborhood && (
+              <div className="mb-4">
+                <span className="inline-flex items-center px-4 py-2 bg-primary/20 backdrop-blur-sm rounded-full text-sm font-medium text-primary-foreground">
+                  <Icon name="MapPin" size={16} className="mr-2" />
+                  {neighborhood}
+                </span>
+              </div>
+            )}
+
+            {title && (
+              <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold mb-6 text-balance text-shadow leading-tight">
+                {title}
+              </h1>
+            )}
+
+            {subtitle && (
+              <p className="text-xl sm:text-2xl mb-8 text-gray-100 text-shadow max-w-2xl">{subtitle}</p>
+            )}
+
+            {(bedrooms || bathrooms || area) && (
+              <div className="flex flex-wrap items-center gap-4 mb-10">
+                {bedrooms && (
+                  <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
+                    <Icon name="Bed" size={20} color="white" />
+                    <span className="text-sm font-semibold">{bedrooms} quartos</span>
+                  </div>
+                )}
+                {bathrooms && (
+                  <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
+                    <Icon name="Bath" size={20} color="white" />
+                    <span className="text-sm font-semibold">{bathrooms} banheiros</span>
+                  </div>
+                )}
+                {area && (
+                  <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
+                    <Icon name="Square" size={20} color="white" />
+                    <span className="text-sm font-semibold">{area}</span>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6">
+              {price && (
+                <div className="text-3xl sm:text-4xl lg:text-5xl font-bold text-primary">{price}</div>
+              )}
+              <div className="flex flex-wrap gap-4">
+                <Button
+                  variant="default"
+                  iconName="MessageCircle"
+                  iconPosition="left"
+                  onClick={onWhatsAppClick}
+                  className="bg-accent hover:bg-accent/90 text-white font-semibold px-6 py-3 text-base shadow-lg hover:shadow-xl transition-all duration-200"
+                >
+                  Detalhes
+                </Button>
+                <Button
+                  variant="outline"
+                  iconName="Phone"
+                  iconPosition="left"
+                  onClick={onCallClick}
+                  className="border-2 border-white text-white hover:bg-white hover:text-gray-900 font-semibold px-6 py-3 text-base backdrop-blur-sm transition-all duration-200"
+                >
+                  Ligar
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HeroSlide;
+

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -621,25 +621,25 @@ export default function Painel() {
                                                 </DialogContent>
                                             </Dialog>
                                         </div>
-                                        <div
-                                            className={cn(
-                                                'mt-4 aspect-video w-full overflow-hidden',
-                                                !newSlide.image_id && 'border-2 border-dashed',
-                                            )}
-                                        >
-                                            {newSlide.image_id && (
-                                                <ImagePreview
-                                                    src={images.find((i) => i.id === newSlide.image_id)?.url ?? ''}
-                                                    titulo={newSlide.title}
-                                                    subtitulo={newSlide.subtitle}
-                                                    preco={newSlide.price}
-                                                    quartos={newSlide.bedrooms}
-                                                    banheiros={newSlide.bathrooms}
-                                                    area={newSlide.area}
-                                                    bairro={newSlide.neighborhood}
-                                                />
-                                            )}
-                                        </div>
+                                    </div>
+                                    <div
+                                        className={cn(
+                                            'mt-4 aspect-video w-full overflow-hidden',
+                                            (!(newSlide.image_id > 0)) && 'border-2 border-dashed',
+                                        )}
+                                    >
+                                        {newSlide.image_id && (
+                                            <ImagePreview
+                                                src={images.find((i) => i.id === newSlide.image_id)?.url ?? ''}
+                                                titulo={newSlide.title}
+                                                subtitulo={newSlide.subtitle}
+                                                preco={newSlide.price}
+                                                quartos={newSlide.bedrooms}
+                                                banheiros={newSlide.bathrooms}
+                                                area={newSlide.area}
+                                                bairro={newSlide.neighborhood}
+                                            />
+                                        )}
                                     </div>
                                     <div className="flex items-end gap-2">
                                         <Button className="w-auto" onClick={submitSlide} disabled={creatingSlide} title="Adicionar Slide">
@@ -918,24 +918,24 @@ export default function Painel() {
                                                 </DialogContent>
                                             </Dialog>
                                         </div>
-                                        <div
-                                            className={cn(
-                                                'mt-4 aspect-video w-full overflow-hidden',
-                                                !newFeatured.image_id && 'border-2 border-dashed',
-                                            )}
-                                        >
-                                            {newFeatured.image_id && (
-                                                <ImagePreview
-                                                    src={images.find((i) => i.id === newFeatured.image_id)?.url ?? ''}
-                                                    titulo={newFeatured.title}
-                                                    preco={newFeatured.price}
-                                                    quartos={newFeatured.bedrooms}
-                                                    banheiros={newFeatured.bathrooms}
-                                                    area={newFeatured.area}
-                                                    bairro={newFeatured.neighborhood}
-                                                />
-                                            )}
-                                        </div>
+                                    </div>
+                                    <div
+                                        className={cn(
+                                            'mt-4 aspect-video w-full overflow-hidden',
+                                            (!(newFeatured.image_id > 0)) && 'border-2 border-dashed',
+                                        )}
+                                    >
+                                        {newFeatured.image_id && (
+                                            <ImagePreview
+                                                src={images.find((i) => i.id === newFeatured.image_id)?.url ?? ''}
+                                                titulo={newFeatured.title}
+                                                preco={newFeatured.price}
+                                                quartos={newFeatured.bedrooms}
+                                                banheiros={newFeatured.bathrooms}
+                                                area={newFeatured.area}
+                                                bairro={newFeatured.neighborhood}
+                                            />
+                                        )}
                                     </div>
                                     <div className="flex items-end gap-2">
                                         <Button className="w-auto" onClick={submitFeatured} disabled={creatingFeatured} title="Adicionar Destaque">


### PR DESCRIPTION
## Summary
- extrai markup do slide da hero para componente reutilizável
- usa HeroSlide no carousel e na pré-visualização com zoom
- ajusta modais do painel para reservar área inferior para preview e remover borda quando há imagem

## Testing
- `npm run lint` *(falhou: command not found: npm)*
- `npm run types` *(falhou: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_b_68c0e7c07a38832ca36e76da00405672