### PR TITLE
Refine slide preview alignment and scaling

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -22,10 +22,10 @@ export default function ImagePreview({
     area,
     bairro,
 }: ImagePreviewProps) {
-    const [zoom, setZoom] = useState(1);
+    const [zoom, setZoom] = useState(0.5);
 
     const zoomIn = () => setZoom((z) => Math.min(z + 0.25, 3));
-    const zoomOut = () => setZoom((z) => Math.max(z - 0.25, 0.5));
+    const zoomOut = () => setZoom((z) => Math.max(z - 0.25, 0.25));
 
     const handleWhatsAppClick = () => {
         const message = encodeURIComponent(
@@ -35,10 +35,10 @@ export default function ImagePreview({
     };
 
     return (
-        <div className="relative aspect-video w-full overflow-hidden rounded-md">
+        <div className="relative aspect-video w-full overflow-hidden rounded-md flex items-center justify-start">
             <div
-                className="h-full w-full transition-transform"
-                style={{ transform: `scale(${zoom})`, transformOrigin: 'center' }}
+                className="h-full w-full transition-transform ml-4"
+                style={{ transform: `scale(${zoom})`, transformOrigin: 'top left' }}
             >
                 <HeroSlide
                     image={src}


### PR DESCRIPTION
## Summary
- Start image preview at half scale for better sizing
- Left-align preview content with margin and top-left origin to mirror hero layout

## Testing
- ⚠️ `npm run lint` (fails: A `require()` style import is forbidden...)
- ⚠️ `npm run types` (fails: Type '{ children: string; variant: string; ... }' is not assignable...)


------
https://chatgpt.com/codex/tasks/task_b_68c0eb882cac832cb3b3682ff02b78a4