### PR TITLE
Align admin preview with hero layout

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -14,44 +14,28 @@ interface ImagePreviewProps {
     bairro?: string | null;
 }
 
-export default function ImagePreview({
-    src,
-    titulo,
-    subtitulo,
-    preco,
-    quartos,
-    banheiros,
-    area,
-    bairro,
-}: ImagePreviewProps) {
+export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, banheiros, area, bairro }: ImagePreviewProps) {
     const [zoom, setZoom] = useState(1);
 
     const zoomIn = () => setZoom((z) => Math.min(z + 0.25, 3));
     const zoomOut = () => setZoom((z) => Math.max(z - 0.25, 0.5));
 
     const handleWhatsAppClick = () => {
-        const message = encodeURIComponent(
-            `Olá! Tenho interesse no imóvel: ${titulo ?? ''} - ${preco ?? ''}. Gostaria de mais informações.`,
-        );
+        const message = encodeURIComponent(`Olá! Tenho interesse no imóvel: ${titulo ?? ''} - ${preco ?? ''}. Gostaria de mais informações.`);
         window.open(`https://wa.me/5562999999999?text=${message}`, '_blank');
     };
 
     return (
         <div className="relative aspect-video w-full overflow-hidden rounded-md">
-            <img
-                src={src}
-                alt={titulo ?? ''}
-                className="h-full w-full object-cover transition-transform"
-                style={{ transform: `scale(${zoom})` }}
-            />
-            <div className="absolute inset-0 hero-overlay" />
+            <img src={src} alt={titulo ?? ''} className="h-full w-full object-cover transition-transform" style={{ transform: `scale(${zoom})` }} />
+            <div className="hero-overlay absolute inset-0" />
 
             <div className="absolute inset-0 flex items-center">
-                <div className="container-responsive">
-                    <div className="max-w-3xl text-white animate-fade-in-up">
+                <div className="p-4">
+                    <div className="animate-fade-in-up max-w-3xl origin-left scale-50 transform text-white">
                         {bairro && (
                             <div className="mb-4">
-                                <span className="inline-flex items-center px-4 py-2 bg-primary/20 backdrop-blur-sm rounded-full text-sm font-medium text-primary-foreground">
+                                <span className="inline-flex items-center rounded-full bg-primary/20 px-4 py-2 text-sm font-medium text-primary-foreground backdrop-blur-sm">
                                     <Icon iconNode={MapPin} size={16} className="mr-2" />
                                     {bairro}
                                 </span>
@@ -59,31 +43,27 @@ export default function ImagePreview({
                         )}
 
                         {titulo && (
-                            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold mb-6 text-balance text-shadow leading-tight">
-                                {titulo}
-                            </h1>
+                            <h1 className="text-shadow mb-6 text-4xl leading-tight font-bold text-balance sm:text-5xl lg:text-6xl">{titulo}</h1>
                         )}
 
-                        {subtitulo && (
-                            <p className="text-xl sm:text-2xl mb-8 text-gray-100 text-shadow max-w-2xl">{subtitulo}</p>
-                        )}
+                        {subtitulo && <p className="text-shadow mb-8 max-w-2xl text-xl text-gray-100 sm:text-2xl">{subtitulo}</p>}
 
                         {(quartos || banheiros || area) && (
-                            <div className="flex flex-wrap items-center gap-4 mb-10">
+                            <div className="mb-10 flex flex-wrap items-center gap-4">
                                 {quartos && (
-                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
+                                    <div className="flex items-center space-x-2 rounded-xl border border-white/10 bg-white/15 px-4 py-3 backdrop-blur-sm">
                                         <Icon iconNode={Bed} size={20} color="white" />
                                         <span className="text-sm font-semibold">{quartos} quartos</span>
                                     </div>
                                 )}
                                 {banheiros && (
-                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
+                                    <div className="flex items-center space-x-2 rounded-xl border border-white/10 bg-white/15 px-4 py-3 backdrop-blur-sm">
                                         <Icon iconNode={Bath} size={20} color="white" />
                                         <span className="text-sm font-semibold">{banheiros} banheiros</span>
                                     </div>
                                 )}
                                 {area && (
-                                    <div className="flex items-center space-x-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10">
+                                    <div className="flex items-center space-x-2 rounded-xl border border-white/10 bg-white/15 px-4 py-3 backdrop-blur-sm">
                                         <Icon iconNode={Square} size={20} color="white" />
                                         <span className="text-sm font-semibold">{area}</span>
                                     </div>
@@ -91,15 +71,13 @@ export default function ImagePreview({
                             </div>
                         )}
 
-                        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6">
-                            {preco && (
-                                <div className="text-3xl sm:text-4xl lg:text-5xl font-bold text-primary">{preco}</div>
-                            )}
+                        <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center">
+                            {preco && <div className="text-3xl font-bold text-primary sm:text-4xl lg:text-5xl">{preco}</div>}
                             <div className="flex flex-wrap gap-4">
                                 <Button
                                     variant="default"
                                     onClick={handleWhatsAppClick}
-                                    className="bg-accent hover:bg-accent/90 text-white font-semibold px-6 py-3 text-base shadow-lg hover:shadow-xl transition-all duration-200"
+                                    className="bg-accent px-6 py-3 text-base font-semibold text-white shadow-lg transition-all duration-200 hover:bg-accent/90 hover:shadow-xl"
                                 >
                                     <Icon iconNode={MessageCircle} size={16} className="mr-2" />
                                     Detalhes
@@ -107,7 +85,7 @@ export default function ImagePreview({
                                 <Button
                                     variant="outline"
                                     onClick={() => window.open('tel:+5562999999999')}
-                                    className="border-2 border-white text-white hover:bg-white hover:text-gray-900 font-semibold px-6 py-3 text-base backdrop-blur-sm transition-all duration-200"
+                                    className="border-2 border-white px-6 py-3 text-base font-semibold text-white backdrop-blur-sm transition-all duration-200 hover:bg-white hover:text-gray-900"
                                 >
                                     <Icon iconNode={Phone} size={16} className="mr-2" />
                                     Ligar
@@ -119,22 +97,13 @@ export default function ImagePreview({
             </div>
 
             <div className="absolute top-4 right-4 flex gap-1">
-                <button
-                    type="button"
-                    onClick={zoomOut}
-                    className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white"
-                >
+                <button type="button" onClick={zoomOut} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
                     -
                 </button>
-                <button
-                    type="button"
-                    onClick={zoomIn}
-                    className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white"
-                >
+                <button type="button" onClick={zoomIn} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
                     +
                 </button>
             </div>
         </div>
     );
 }
-


### PR DESCRIPTION
## Summary
- Scale down hero slide preview and anchor content to left for closer visual match

## Testing
- `npm run lint` *(fails: 'module' is not defined in main/postcss.config.js, ...)*
- `npm run format:check` *(fails: code style issues in multiple files)*
- `npm run types` *(fails: declaration conflicts in routes/password/index.ts)*


------
https://chatgpt.com/codex/tasks/task_b_68c0f6eb5d20832c8328ab2f34f7e94e