### PR TITLE
Align preview layout and price color with hero

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -31,7 +31,7 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
             <div className="hero-overlay absolute inset-0" />
 
             <div className="absolute inset-0 flex items-center">
-                <div className="p-4">
+                <div className="container-responsive pl-8 sm:pl-12">
                     <div className="animate-fade-in-up max-w-3xl origin-left scale-50 transform text-white">
                         {bairro && (
                             <div className="mb-4">
@@ -72,7 +72,7 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
                         )}
 
                         <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center">
-                            {preco && <div className="text-3xl font-bold text-primary sm:text-4xl lg:text-5xl">{preco}</div>}
+                            {preco && <div className="text-3xl font-bold text-primary text-[#22c55e] sm:text-4xl lg:text-5xl">{preco}</div>}
                             <div className="flex flex-wrap gap-4">
                                 <Button
                                     variant="default"


### PR DESCRIPTION
## Summary
- align ImagePreview content away from edge using container-responsive padding
- enforce green price color to match hero styling

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-require-imports, react-hooks/rules-of-hooks, and other pre-existing warnings)*
- `npm run types` *(fails: TS2395/TS2440 in resources/js/routes/password/index.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68c0fb0d49c0832cb2d97442c950108c