### PR TITLE
Tweak hero slide preview sizing and colors

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -31,11 +31,11 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
             <div className="hero-overlay absolute inset-0" />
 
             <div className="absolute inset-0 flex items-center">
-                <div className="container-responsive pl-32 sm:pl-48">
+                <div className="container-responsive pl-12 sm:pl-24">
                     <div className="animate-fade-in-up max-w-3xl origin-left scale-50 transform text-white">
                         {bairro && (
                             <div className="mb-4">
-                                <span className="inline-flex items-center rounded-full bg-primary/20 px-4 py-2 text-sm font-medium text-primary-foreground backdrop-blur-sm">
+                                <span className="inline-flex items-center rounded-full bg-[#22c55e]/20 px-4 py-2 text-sm font-medium text-white backdrop-blur-sm">
                                     <Icon iconNode={MapPin} size={16} className="mr-2" />
                                     {bairro}
                                 </span>
@@ -72,7 +72,7 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
                         )}
 
                         <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center">
-                            {preco && <div className="text-3xl font-bold text-primary text-[#22c55e] sm:text-4xl lg:text-5xl">{preco}</div>}
+                            {preco && <div className="text-3xl font-bold text-[#22c55e] sm:text-4xl lg:text-5xl">{preco}</div>}
                             <div className="flex flex-wrap gap-4">
                                 <Button
                                     variant="default"


### PR DESCRIPTION
## Summary
- shrink and reposition hero slide preview toward the left
- use explicit hero green for badge and price to match hero colors

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden, 'require' is not defined, many unused vars and no-empty)*
- `npm run format:check` *(fails: Code style issues found in 83 files. Run Prettier with --write to fix.)*
- `npm run types` *(fails: Individual declarations in merged declaration 'confirm' must be all exported or all local)*

------
https://chatgpt.com/codex/tasks/task_b_68c1016139e4832c8d54b6c08394850d