### PR TITLE
Center ImagePreview overlay and fix price color

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -29,8 +29,8 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
             <img src={src} alt={titulo ?? ''} className="h-full w-full object-cover transition-transform" style={{ transform: `scale(${zoom})` }} />
             <div className="hero-overlay absolute inset-0" />
 
-            <div className="absolute inset-0 flex items-center justify-start">
-                <div className="px-8">
+            <div className="absolute inset-0 flex items-center justify-center">
+                <div className="px-8 mx-auto">
                     <div className="animate-fade-in-up max-w-3xl origin-left scale-50 transform text-white">
                         {bairro && (
                             <div className="mb-4">
@@ -71,7 +71,7 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
                         )}
 
                         <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center">
-                            {preco && <div className="text-3xl font-bold text-primary sm:text-4xl lg:text-5xl">{preco}</div>}
+                            {preco && <div className="text-3xl font-bold text-green-500 sm:text-4xl lg:text-5xl">{preco}</div>}
                             <div className="flex flex-wrap gap-4">
                                 <Button
                                     variant="default"


### PR DESCRIPTION
## Summary
- center overlay content in ImagePreview
- apply fixed green color to price

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm run build` *(fails: @laravel/vite-plugin-wayfinder Error generating types)*

------
https://chatgpt.com/codex/tasks/task_b_68c213ab5f7c832c81998c00bca76e27