### PR TITLE
Ajusta alinhamento do conteúdo no ImagePreview

### DIFF
--- a/resources/js/components/ImagePreview.tsx
+++ b/resources/js/components/ImagePreview.tsx
@@ -29,8 +29,8 @@ export default function ImagePreview({ src, titulo, subtitulo, preco, quartos, b
             <img src={src} alt={titulo ?? ''} className="h-full w-full object-cover transition-transform" style={{ transform: `scale(${zoom})` }} />
             <div className="hero-overlay absolute inset-0" />
 
-            <div className="absolute inset-0 flex items-center justify-center">
-                <div className="px-8 mx-auto">
+            <div className="absolute inset-0 flex items-center justify-start pl-16">
+                <div className="px-8">
                     <div className="animate-fade-in-up max-w-3xl origin-left scale-50 transform text-white">
                         {bairro && (
                             <div className="mb-4">


### PR DESCRIPTION
## Summary
- alinha texto e botões da pré-visualização de imagem mais à esquerda com espaçamento

## Testing
- `npx eslint resources/js/components/ImagePreview.tsx`
- `npm run lint` (falha: erros existentes em arquivos não relacionados)
- `npm run types` (falha: erros em resources/js/routes/password/index.ts)
- `npm test` (falha: script ausente)


------
https://chatgpt.com/codex/tasks/task_b_68c21aabd870832c9107e6c0c39f8d39