### PR TITLE
Handle processed images and delay hero carousel until slides load

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -11,7 +11,7 @@ class ImageController extends Controller
 {
     public function index(): JsonResponse
     {
-        $images = Image::query()->latest('id')->get();
+        $images = Image::query()->where('origin', 'upload')->latest('id')->get();
         return response()->json($images);
     }
 
@@ -20,10 +20,12 @@ class ImageController extends Controller
         $validated = $request->validate([
             'images'   => ['required', 'array', 'max:20'],
             'images.*' => ['file', 'image', 'mimes:jpeg,jpg,png,gif,webp', 'max:5120'], // 5MB por arquivo
+            'origin'   => ['sometimes', 'in:upload,processed'],
         ]);
 
         $saved = [];
         $disk = 'public';
+        $origin = $validated['origin'] ?? 'upload';
 
         foreach ($request->file('images', []) as $file) {
             $path = $file->store('images', $disk);
@@ -52,6 +54,7 @@ class ImageController extends Controller
                 'mime_type'     => $mime,
                 'width'         => $width,
                 'height'        => $height,
+                'origin'        => $origin,
             ]);
 
             $saved[] = $image;

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -16,6 +16,7 @@ class Image extends Model
         'mime_type',
         'width',
         'height',
+        'origin',
     ];
 
     protected $appends = ['url'];

--- a/database/migrations/2025_09_11_025827_add_origin_to_images_table.php
+++ b/database/migrations/2025_09_11_025827_add_origin_to_images_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('images', function (Blueprint $table) {
+            $table->string('origin')->default('upload')->after('height');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('images', function (Blueprint $table) {
+            $table->dropColumn('origin');
+        });
+    }
+};

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
@@ -6,6 +6,7 @@ import Button from '../../../components/ui/Button';
 const HeroCarousel = () => {
   const [currentSlide, setCurrentSlide] = useState(0);
   const [heroProperties, setHeroProperties] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     (async () => {
@@ -28,70 +29,23 @@ const HeroCarousel = () => {
           setHeroProperties(mapped);
         }
       } catch {}
+      setLoading(false);
     })();
   }, []);
-
-  const heroPropertiesStatic = [
-    {
-      id: 1,
-      title: "Casa de Luxo no Setor Bueno",
-      subtitle: "Sua nova casa nos melhores bairros de Goiânia",
-      image: "https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?w=1920&h=1080&fit=crop&crop=center&auto=format&q=90",
-      price: "R$ 1.850.000",
-      bedrooms: 4,
-      bathrooms: 3,
-      area: "320m²",
-      neighborhood: "Setor Bueno"
-    },
-    {
-      id: 2,
-      title: "Apartamento Premium Jardim Goiás",
-      subtitle: "Viva com sofisticação próximo ao Flamboyant",
-      image: "https://images.unsplash.com/photo-1600607687939-ce8a6c25118c?w=1920&h=1080&fit=crop&crop=center&auto=format&q=90",
-      price: "R$ 1.200.000",
-      bedrooms: 3,
-      bathrooms: 2,
-      area: "180m²",
-      neighborhood: "Jardim Goiás"
-    },
-    {
-      id: 3,
-      title: "Cobertura Alto da Glória",
-      subtitle: "Exclusividade e vista panorâmica da cidade",
-      image: "https://images.unsplash.com/photo-1600566753190-17f0baa2a6c3?w=1920&h=1080&fit=crop&crop=center&auto=format&q=90",
-      price: "R$ 2.400.000",
-      bedrooms: 5,
-      bathrooms: 4,
-      area: "450m²",
-      neighborhood: "Alto da Glória"
-    },
-    {
-      id: 4,
-      title: "Casa Moderna Setor Marista",
-      subtitle: "Arquitetura contemporânea em localização privilegiada",
-      image: "https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=1920&h=1080&fit=crop&crop=center&auto=format&q=90",
-      price: "R$ 1.650.000",
-      bedrooms: 4,
-      bathrooms: 3,
-      area: "280m²",
-      neighborhood: "Setor Marista"
-    }
-  ];
-
   useEffect(() => {
-    const list = heroProperties?.length ? heroProperties : heroPropertiesStatic;
+    if (!heroProperties.length) return;
     const interval = setInterval(() => {
-      setCurrentSlide((prev) => (list.length ? (prev + 1) % list.length : 0));
+      setCurrentSlide((prev) => (prev + 1) % heroProperties.length);
     }, 6000);
     return () => clearInterval(interval);
-  }, [heroProperties?.length]);
+  }, [heroProperties.length]);
 
   const nextSlide = () => {
-    setCurrentSlide((prev) => (prev + 1) % heroProperties?.length);
+    setCurrentSlide((prev) => (prev + 1) % heroProperties.length);
   };
 
   const prevSlide = () => {
-    setCurrentSlide((prev) => (prev - 1 + heroProperties?.length) % heroProperties?.length);
+    setCurrentSlide((prev) => (prev - 1 + heroProperties.length) % heroProperties.length);
   };
 
   const handleWhatsAppClick = (property) => {
@@ -99,10 +53,13 @@ const HeroCarousel = () => {
     window.open(`https://wa.me/5562999999999?text=${message}`, '_blank');
   };
 
+  if (loading) return <div className="w-full h-[400px] bg-gray-900" />;
+  if (!heroProperties.length) return null;
+
   return (
     <section className="relative w-full hero-carousel bg-gray-900 overflow-hidden">
       <div className="relative w-full h-full">
-        {(heroProperties?.length ? heroProperties : heroPropertiesStatic).map((property, index) => (
+        {heroProperties.map((property, index) => (
           <div
             key={property?.id}
             className={`absolute inset-0 transition-all duration-1000 ${

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -242,7 +242,8 @@ export default function Painel() {
             let image_id = selectedSlideImage.id;
             if (editedSlideBlob) {
                 const fd = new FormData();
-                fd.append('images[]', editedSlideBlob, 'preview-editada.png');
+                fd.append('images[]', editedSlideBlob, 'preview.png');
+                fd.append('origin', 'processed');
                 const uploaded = await apiFetch<Image[]>(ImageActions.store(), { body: fd });
                 if (uploaded[0]?.id) image_id = uploaded[0].id;
             }
@@ -332,7 +333,8 @@ export default function Painel() {
             let image_id = selectedFeaturedImage.id;
             if (editedFeaturedBlob) {
                 const fd = new FormData();
-                fd.append('images[]', editedFeaturedBlob, 'preview-editada.png');
+                fd.append('images[]', editedFeaturedBlob, 'preview.png');
+                fd.append('origin', 'processed');
                 const uploaded = await apiFetch<Image[]>(ImageActions.store(), { body: fd });
                 if (uploaded[0]?.id) image_id = uploaded[0].id;
             }


### PR DESCRIPTION
## Summary
- Avoid flashing demo images in `HeroCarousel` by rendering only after hero slides load
- Tag stored images with an `origin` column and filter gallery to show only uploads
- Mark edited slide/featured images as processed when saving from the panel

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=/workspace/casa_conecta_imoveis/database/database.sqlite php artisan migrate:fresh --no-interaction`
- `npm run lint` *(fails: A `require()` style import is forbidden, `useLocation` hook called conditionally, various unused vars)*
- `DB_CONNECTION=sqlite DB_DATABASE=/workspace/casa_conecta_imoveis/database/database.sqlite composer test`


------
https://chatgpt.com/codex/tasks/task_b_68c23a7e88d8832c8e48710e35e60072