### PR TITLE
refactor: modular image editor components

### DIFF
--- a/resources/js/components/ImageEditor.tsx
+++ b/resources/js/components/ImageEditor.tsx
@@ -1,0 +1,66 @@
+import { ReactNode } from 'react';
+import { useImageEditor } from '@/hooks/useImageEditor';
+import ImageFilters from './ImageFilters';
+
+interface ImageEditorProps {
+    src: string;
+    onExport?: (blob: Blob | null) => void;
+    children?: ReactNode;
+}
+
+export default function ImageEditor({ src, onExport, children }: ImageEditorProps) {
+    const {
+        imgRef,
+        containerRef,
+        zoom,
+        brightness,
+        contrast,
+        saturation,
+        setBrightness,
+        setContrast,
+        setSaturation,
+        zoomIn,
+        zoomOut,
+    } = useImageEditor({ src, onExport });
+
+    return (
+        <div ref={containerRef} className="relative aspect-video w-full overflow-hidden rounded-md">
+            <img
+                ref={imgRef}
+                src={src}
+                alt=""
+                className="h-full w-full object-cover transition-transform"
+                style={{
+                    transform: `scale(${zoom})`,
+                    transformOrigin: 'center',
+                    filter: `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturation}%)`,
+                }}
+            />
+            {children}
+            <div className="absolute top-4 right-4 flex gap-1">
+                <button
+                    type="button"
+                    onClick={zoomOut}
+                    className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white"
+                >
+                    -
+                </button>
+                <button
+                    type="button"
+                    onClick={zoomIn}
+                    className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white"
+                >
+                    +
+                </button>
+            </div>
+            <ImageFilters
+                brightness={brightness}
+                contrast={contrast}
+                saturation={saturation}
+                setBrightness={setBrightness}
+                setContrast={setContrast}
+                setSaturation={setSaturation}
+            />
+        </div>
+    );
+}

--- a/resources/js/hooks/useImageEditor.ts
+++ b/resources/js/hooks/useImageEditor.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { exportEditedImage as exportImage } from '../utils/exportEditedImage';
+
+interface UseImageEditorOptions {
+    src: string;
+    onExport?: (blob: Blob | null) => void;
+}
+
+export function useImageEditor({ src, onExport }: UseImageEditorOptions) {
+    const [zoom, setZoom] = useState(1);
+    const [brightness, setBrightness] = useState(100);
+    const [contrast, setContrast] = useState(100);
+    const [saturation, setSaturation] = useState(100);
+
+    const imgRef = useRef<HTMLImageElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const zoomIn = () => setZoom((z) => Math.min(z + 0.25, 3));
+    const zoomOut = () => setZoom((z) => Math.max(z - 0.25, 0.5));
+
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container) return;
+        const wheelHandler = (e: WheelEvent) => {
+            e.preventDefault();
+            setZoom((z) => Math.min(Math.max(z + (e.deltaY < 0 ? 0.25 : -0.25), 0.5), 3));
+        };
+        container.addEventListener('wheel', wheelHandler, { passive: false });
+        return () => {
+            container.removeEventListener('wheel', wheelHandler);
+        };
+    }, []);
+
+    const exportEditedImage = useCallback(async (): Promise<Blob | null> => {
+        if (!imgRef.current || !containerRef.current) return null;
+        try {
+            return await exportImage(imgRef.current, containerRef.current, {
+                zoom,
+                brightness,
+                contrast,
+                saturation,
+            });
+        } catch {
+            return null;
+        }
+    }, [zoom, brightness, contrast, saturation]);
+
+    useEffect(() => {
+        if (!onExport) return;
+        const img = imgRef.current;
+        const container = containerRef.current;
+        if (!img || !container) return;
+        const hasEdits = zoom !== 1 || brightness !== 100 || contrast !== 100 || saturation !== 100;
+        const exportAndSend = async () => {
+            if (!hasEdits) {
+                onExport(null);
+                return;
+            }
+            const blob = await exportEditedImage();
+            onExport(blob);
+        };
+        let timeout: ReturnType<typeof setTimeout>;
+        const run = () => {
+            timeout = setTimeout(exportAndSend, 300);
+        };
+        if (img.complete) {
+            run();
+        } else {
+            img.onload = run;
+        }
+        return () => {
+            clearTimeout(timeout);
+            if (img) img.onload = null;
+        };
+    }, [zoom, brightness, contrast, saturation, src, exportEditedImage, onExport]);
+
+    return {
+        imgRef,
+        containerRef,
+        zoom,
+        setZoom,
+        brightness,
+        setBrightness,
+        contrast,
+        setContrast,
+        saturation,
+        setSaturation,
+        zoomIn,
+        zoomOut,
+        exportEditedImage,
+    };
+}
+
+export type UseImageEditorReturn = ReturnType<typeof useImageEditor>;

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -1,4 +1,5 @@
-import ImagePreview from '@/components/ImagePreview';
+import ImageEditor from '@/components/ImageEditor';
+import ImagePreviewOverlay from '@/components/ImagePreviewOverlay';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -665,17 +666,17 @@ export default function Painel() {
                                             )}
                                         >
                                             {selectedSlideImage && (
-                                                <ImagePreview
-                                                    src={selectedSlideImage.url}
-                                                    titulo={newSlide.title}
-                                                    subtitulo={newSlide.subtitle}
-                                                    preco={newSlide.price}
-                                                    quartos={newSlide.bedrooms}
-                                                    banheiros={newSlide.bathrooms}
-                                                    area={newSlide.area}
-                                                    bairro={newSlide.neighborhood}
-                                                    onExport={setEditedSlideBlob}
-                                                />
+                                                <ImageEditor src={selectedSlideImage.url} onExport={setEditedSlideBlob}>
+                                                    <ImagePreviewOverlay
+                                                        titulo={newSlide.title}
+                                                        subtitulo={newSlide.subtitle}
+                                                        preco={newSlide.price}
+                                                        quartos={newSlide.bedrooms}
+                                                        banheiros={newSlide.bathrooms}
+                                                        area={newSlide.area}
+                                                        bairro={newSlide.neighborhood}
+                                                    />
+                                                </ImageEditor>
                                             )}
                                         </div>
                                     </div>
@@ -970,16 +971,16 @@ export default function Painel() {
                                             )}
                                         >
                                             {selectedFeaturedImage && (
-                                                <ImagePreview
-                                                    src={selectedFeaturedImage.url}
-                                                    titulo={newFeatured.title}
-                                                    preco={newFeatured.price}
-                                                    quartos={newFeatured.bedrooms}
-                                                    banheiros={newFeatured.bathrooms}
-                                                    area={newFeatured.area}
-                                                    bairro={newFeatured.neighborhood}
-                                                    onExport={setEditedFeaturedBlob}
-                                                />
+                                                <ImageEditor src={selectedFeaturedImage.url} onExport={setEditedFeaturedBlob}>
+                                                    <ImagePreviewOverlay
+                                                        titulo={newFeatured.title}
+                                                        preco={newFeatured.price}
+                                                        quartos={newFeatured.bedrooms}
+                                                        banheiros={newFeatured.bathrooms}
+                                                        area={newFeatured.area}
+                                                        bairro={newFeatured.neighborhood}
+                                                    />
+                                                </ImageEditor>
                                             )}
                                         </div>
                                     </div>


### PR DESCRIPTION
## Summary
- create reusable `useImageEditor` hook for zoom and filters
- add generic `ImageEditor` component and overlay-only `ImagePreviewOverlay`
- update painel page to compose editor and overlay instead of `ImagePreview`

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c24e4b8fcc832c8e2a577223bb85e9