### PR TITLE
Ensure delete account dialog includes accessible description

### DIFF
--- a/resources/js/components/delete-user.tsx
+++ b/resources/js/components/delete-user.tsx
@@ -2,7 +2,16 @@ import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileCo
 import HeadingSmall from '@/components/heading-small';
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Form } from '@inertiajs/react';
@@ -24,9 +33,11 @@ export default function DeleteUser() {
                     <DialogTrigger asChild>
                         <Button variant="destructive">Delete account</Button>
                     </DialogTrigger>
-                    <DialogContent>
-                        <DialogTitle>Are you sure you want to delete your account?</DialogTitle>
-                        <DialogDescription>
+                    <DialogContent aria-describedby="delete-account-desc">
+                        <DialogHeader>
+                            <DialogTitle>Are you sure you want to delete your account?</DialogTitle>
+                        </DialogHeader>
+                        <DialogDescription id="delete-account-desc">
                             Once your account is deleted, all of its resources and data will also be permanently deleted. Please enter your password
                             to confirm you would like to permanently delete your account.
                         </DialogDescription>


### PR DESCRIPTION
## Summary
- add DialogHeader and DialogDescription with id for delete account modal
- link DialogContent to description via aria-describedby

## Testing
- `npm run lint` *(fails: 'require' is not defined, useLocation called conditionally, unused vars, etc.)*
- `npm run types` *(fails: type mismatch in painel.tsx, import conflicts in routes/password/index.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68c2cf17e88c832c8f15f63c0b6c9fca