### PR TITLE
refactor: centralize footer component across public pages

### DIFF
--- a/main/src/components/Footer.jsx
+++ b/main/src/components/Footer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Icon from '../../../components/AppIcon';
+import Icon from './AppIcon';
 
 const Footer = () => {
   const currentYear = new Date()?.getFullYear();

--- a/main/src/pages/about-brand-story-credentials/index.jsx
+++ b/main/src/pages/about-brand-story-credentials/index.jsx
@@ -9,6 +9,7 @@ import ClientSuccessSection from './components/ClientSuccessSection';
 import ProcessTransparencySection from './components/ProcessTransparencySection';
 import NeighborhoodExpertiseSection from './components/NeighborhoodExpertiseSection';
 import ContactSection from './components/ContactSection';
+import Footer from '../../components/Footer';
 
 const AboutBrandStoryCredentials = () => {
   useEffect(() => {
@@ -60,55 +61,7 @@ const AboutBrandStoryCredentials = () => {
         </button>
 
         {/* Footer */}
-        <footer className="bg-text-primary text-white py-12">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="grid lg:grid-cols-4 gap-8">
-              <div className="lg:col-span-2">
-                <div className="flex items-center space-x-3 mb-4">
-                  <div className="w-10 h-10 bg-primary rounded-lg flex items-center justify-center">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="white">
-                      <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-                    </svg>
-                  </div>
-                  <div>
-                    <h3 className="text-xl font-bold">Casa Conecta</h3>
-                    <p className="text-sm opacity-80">Imóveis Premium</p>
-                  </div>
-                </div>
-                <p className="text-sm opacity-80 mb-4 max-w-md">
-                  Conectando famílias aos seus lares ideais em Goiânia há mais de 6 anos. 
-                  Consultoria especializada em imóveis premium com atendimento personalizado.
-                </p>
-                <div className="text-xs opacity-60">
-                  CRECI-GO 12345 | CNPJ: 12.345.678/0001-90
-                </div>
-              </div>
-              
-              <div>
-                <h4 className="font-semibold mb-4">Contato</h4>
-                <div className="space-y-2 text-sm opacity-80">
-                  <div>(62) 99999-9999</div>
-                  <div>contato@casaconecta.com.br</div>
-                  <div>Rua T-25, 123 - Setor Bueno</div>
-                  <div>Goiânia - GO</div>
-                </div>
-              </div>
-              
-              <div>
-                <h4 className="font-semibold mb-4">Horários</h4>
-                <div className="space-y-2 text-sm opacity-80">
-                  <div>Segunda a Sexta: 8h às 18h</div>
-                  <div>Sábado: 8h às 12h</div>
-                  <div className="text-primary font-medium">WhatsApp: 24/7</div>
-                </div>
-              </div>
-            </div>
-            
-            <div className="border-t border-white/20 mt-8 pt-8 text-center text-sm opacity-60">
-              <p>&copy; {new Date()?.getFullYear()} Casa Conecta Imóveis. Todos os direitos reservados.</p>
-            </div>
-          </div>
-        </footer>
+        <Footer />
       </div>
     </>
   );

--- a/main/src/pages/faq-comprehensive-buyer-education/index.jsx
+++ b/main/src/pages/faq-comprehensive-buyer-education/index.jsx
@@ -6,6 +6,7 @@ import CategoryFilter from './components/CategoryFilter';
 import FAQItem from './components/FAQItem';
 import ConsultationSection from './components/ConsultationSection';
 import Icon from '../../components/AppIcon';
+import Footer from '../../components/Footer';
 
 const FAQPage = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -621,31 +622,7 @@ Nosso compromisso não termina na entrega das chaves. Queremos que você tenha u
         <Icon name="MessageCircle" size={24} />
       </button>
       {/* Footer */}
-      <footer className="bg-text-primary text-white py-8">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center">
-            <div className="flex items-center justify-center space-x-3 mb-4">
-              <div className="w-10 h-10 bg-gradient-to-br from-primary to-secondary rounded-lg flex items-center justify-center">
-                <Icon name="Home" size={24} color="white" strokeWidth={2.5} />
-              </div>
-              <div>
-                <h3 className="text-xl font-bold">Casa Conecta</h3>
-                <p className="text-sm opacity-80">Imóveis Premium</p>
-              </div>
-            </div>
-            <p className="text-sm opacity-80 mb-4">
-              Especialistas em imóveis premium nos melhores bairros de Goiânia
-            </p>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-4 text-sm opacity-70">
-              <span>CRECI-GO: 123456</span>
-              <span className="hidden sm:block">•</span>
-              <span>© {new Date()?.getFullYear()} Casa Conecta Imóveis</span>
-              <span className="hidden sm:block">•</span>
-              <span>Todos os direitos reservados</span>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 };

--- a/main/src/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/main/src/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -8,7 +8,7 @@ import TestimonialsSection from './components/TestimonialsSection';
 import ConsultationHub from './components/ConsultationHub';
 import NeighborhoodMap from './components/NeighborhoodMap';
 import WhatsAppFloat from './components/WhatsAppFloat';
-import Footer from './components/Footer';
+import Footer from '../../components/Footer';
 
 const HomepagePremiumRealEstateConsultancy = () => {
   const [filters, setFilters] = useState({

--- a/resources/js/main/components/Footer.jsx
+++ b/resources/js/main/components/Footer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Icon from '../../../components/AppIcon';
+import Icon from './AppIcon';
 
 const Footer = () => {
   const currentYear = new Date()?.getFullYear();

--- a/resources/js/main/pages/about-brand-story-credentials/index.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/index.jsx
@@ -9,6 +9,7 @@ import ClientSuccessSection from './components/ClientSuccessSection';
 import ProcessTransparencySection from './components/ProcessTransparencySection';
 import NeighborhoodExpertiseSection from './components/NeighborhoodExpertiseSection';
 import ContactSection from './components/ContactSection';
+import Footer from '../../components/Footer';
 
 const AboutBrandStoryCredentials = () => {
   useEffect(() => {
@@ -60,55 +61,7 @@ const AboutBrandStoryCredentials = () => {
         </button>
 
         {/* Footer */}
-        <footer className="bg-text-primary text-white py-12">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="grid lg:grid-cols-4 gap-8">
-              <div className="lg:col-span-2">
-                <div className="flex items-center space-x-3 mb-4">
-                  <div className="w-10 h-10 bg-primary rounded-lg flex items-center justify-center">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="white">
-                      <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-                    </svg>
-                  </div>
-                  <div>
-                    <h3 className="text-xl font-bold">Casa Conecta</h3>
-                    <p className="text-sm opacity-80">Imóveis Premium</p>
-                  </div>
-                </div>
-                <p className="text-sm opacity-80 mb-4 max-w-md">
-                  Conectando famílias aos seus lares ideais em Goiânia há mais de 6 anos. 
-                  Consultoria especializada em imóveis premium com atendimento personalizado.
-                </p>
-                <div className="text-xs opacity-60">
-                  CRECI-GO 12345 | CNPJ: 12.345.678/0001-90
-                </div>
-              </div>
-              
-              <div>
-                <h4 className="font-semibold mb-4">Contato</h4>
-                <div className="space-y-2 text-sm opacity-80">
-                  <div>(62) 99999-9999</div>
-                  <div>contato@casaconecta.com.br</div>
-                  <div>Rua T-25, 123 - Setor Bueno</div>
-                  <div>Goiânia - GO</div>
-                </div>
-              </div>
-              
-              <div>
-                <h4 className="font-semibold mb-4">Horários</h4>
-                <div className="space-y-2 text-sm opacity-80">
-                  <div>Segunda a Sexta: 8h às 18h</div>
-                  <div>Sábado: 8h às 12h</div>
-                  <div className="text-primary font-medium">WhatsApp: 24/7</div>
-                </div>
-              </div>
-            </div>
-            
-            <div className="border-t border-white/20 mt-8 pt-8 text-center text-sm opacity-60">
-              <p>&copy; {new Date()?.getFullYear()} Casa Conecta Imóveis. Todos os direitos reservados.</p>
-            </div>
-          </div>
-        </footer>
+        <Footer />
       </div>
     </>
   );

--- a/resources/js/main/pages/faq-comprehensive-buyer-education/index.jsx
+++ b/resources/js/main/pages/faq-comprehensive-buyer-education/index.jsx
@@ -6,6 +6,7 @@ import CategoryFilter from './components/CategoryFilter';
 import FAQItem from './components/FAQItem';
 import ConsultationSection from './components/ConsultationSection';
 import Icon from '../../components/AppIcon';
+import Footer from '../../components/Footer';
 
 const FAQPage = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -621,31 +622,7 @@ Nosso compromisso não termina na entrega das chaves. Queremos que você tenha u
         <Icon name="MessageCircle" size={24} />
       </button>
       {/* Footer */}
-      <footer className="bg-text-primary text-white py-8">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center">
-            <div className="flex items-center justify-center space-x-3 mb-4">
-              <div className="w-10 h-10 bg-gradient-to-br from-primary to-secondary rounded-lg flex items-center justify-center">
-                <Icon name="Home" size={24} color="white" strokeWidth={2.5} />
-              </div>
-              <div>
-                <h3 className="text-xl font-bold">Casa Conecta</h3>
-                <p className="text-sm opacity-80">Imóveis Premium</p>
-              </div>
-            </div>
-            <p className="text-sm opacity-80 mb-4">
-              Especialistas em imóveis premium nos melhores bairros de Goiânia
-            </p>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-4 text-sm opacity-70">
-              <span>CRECI-GO: 123456</span>
-              <span className="hidden sm:block">•</span>
-              <span>© {new Date()?.getFullYear()} Casa Conecta Imóveis</span>
-              <span className="hidden sm:block">•</span>
-              <span>Todos os direitos reservados</span>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 };

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -8,7 +8,7 @@ import TestimonialsSection from './components/TestimonialsSection';
 import ConsultationHub from './components/ConsultationHub';
 import NeighborhoodMap from './components/NeighborhoodMap';
 import WhatsAppFloat from './components/WhatsAppFloat';
-import Footer from './components/Footer';
+import Footer from '../../components/Footer';
 
 const HomepagePremiumRealEstateConsultancy = () => {
   const [filters, setFilters] = useState({


### PR DESCRIPTION
## Summary
- extract reusable Footer component and mirror to `main/src`
- replace inline footers in About, FAQ, and Home pages
- update imports to use shared component

## Testing
- `npm run lint` *(fails: 'require' is not defined, React hook called conditionally, unused vars)*
- `npm run dev`
- `cd main && npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68c2db913f94832c8f935ca186fdcbb9