### PR TITLE
fix: align search button with filters

### DIFF
--- a/main/src/pages/homepage-premium-real-estate-consultancy/components/FeaturedProperties.jsx
+++ b/main/src/pages/homepage-premium-real-estate-consultancy/components/FeaturedProperties.jsx
@@ -237,7 +237,7 @@ const FeaturedProperties = () => {
       </div>
 
         <div className="mb-12 w-full bg-gray-50 p-6 rounded-2xl">
-          <div className="mb-6 grid w-full grid-cols-1 gap-4 md:grid-cols-4">
+          <div className="mb-6 grid w-full grid-cols-1 gap-4 md:grid-cols-[repeat(3,1fr)_auto]">
             <div className="space-y-2">
               <label className="block text-sm font-medium text-gray-700">
                 <Icon name="MapPin" size={16} className="mr-2 inline" />
@@ -292,8 +292,8 @@ const FeaturedProperties = () => {
               </select>
             </div>
 
-            <div className="flex items-end">
-              <Button className="w-full h-full" variant="default" iconName="Search" iconPosition="left" onClick={applyFilters}>
+            <div className="flex items-end justify-center">
+              <Button className="h-12 px-6" variant="default" iconName="Search" iconPosition="left" onClick={applyFilters}>
                 Buscar Imóveis
               </Button>
             </div>

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/FeaturedProperties.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/FeaturedProperties.jsx
@@ -267,7 +267,7 @@ const FeaturedProperties = () => {
       </div>
 
       <div className="mb-12 w-full bg-gray-50 p-6 rounded-2xl">
-        <div className="mb-6 grid w-full grid-cols-1 gap-4 md:grid-cols-4">
+        <div className="mb-6 grid w-full grid-cols-1 gap-4 md:grid-cols-[repeat(3,1fr)_auto]">
           <div className="space-y-2">
             <label className="block text-sm font-medium text-gray-700">
               <Icon name="MapPin" size={16} className="mr-2 inline" />
@@ -322,8 +322,8 @@ const FeaturedProperties = () => {
             </select>
           </div>
 
-          <div className="flex items-end">
-            <Button className="w-full h-full" variant="default" iconName="Search" iconPosition="left" onClick={applyFilters}>
+          <div className="flex items-end justify-center">
+            <Button className="h-12 px-6" variant="default" iconName="Search" iconPosition="left" onClick={applyFilters}>
               Buscar Imóveis
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- keep filter button sized like selects and center it in grid

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint resources/js/main/pages/homepage-premium-real-estate-consultancy/components/FeaturedProperties.jsx main/src/pages/homepage-premium-real-estate-consultancy/components/FeaturedProperties.jsx` *(warns: File ignored because no matching configuration was supplied)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68c32a560004832ca4bf49e3ba41d6b5