### PR TITLE
fix: avoid dark surfaces on marketing pages

### DIFF
--- a/main/src/pages/about-brand-story-credentials/components/ClientSuccessSection.jsx
+++ b/main/src/pages/about-brand-story-credentials/components/ClientSuccessSection.jsx
@@ -94,7 +94,7 @@ const ClientSuccessSection = () => {
   ];
 
   return (
-    <section className="py-16 bg-surface">
+    <section className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl lg:text-4xl font-bold text-text-primary mb-4">

--- a/main/src/pages/about-brand-story-credentials/components/ContactSection.jsx
+++ b/main/src/pages/about-brand-story-credentials/components/ContactSection.jsx
@@ -118,7 +118,8 @@ const ContactSection = () => {
                     key={index}
                     className={`p-6 rounded-xl border-2 transition-all duration-200 cursor-pointer ${
                       method?.highlight
-                        ? 'border-primary bg-primary/5 hover:bg-primary/10' :'border-border bg-surface hover:border-primary/50'
+                        ? 'border-primary bg-primary/5 hover:bg-primary/10'
+                        : 'border-border bg-gray-50 hover:border-primary/50'
                     }`}
                     onClick={method?.onClick}
                   >
@@ -152,7 +153,7 @@ const ContactSection = () => {
             </div>
 
             {/* Office Information */}
-            <div className="bg-surface rounded-xl p-6">
+            <div className="bg-gray-50 rounded-xl p-6">
               <h4 className="font-semibold text-text-primary mb-4 flex items-center">
                 <Icon name="MapPin" size={20} className="mr-2 text-primary" />
                 Nosso Escritório
@@ -171,7 +172,7 @@ const ContactSection = () => {
 
           {/* Contact Form */}
           <div>
-            <div className="bg-surface rounded-xl p-8">
+            <div className="bg-gray-50 rounded-xl p-8">
               <h3 className="text-2xl font-bold text-text-primary mb-6">
                 Solicite uma Consulta
               </h3>

--- a/main/src/pages/about-brand-story-credentials/components/CredentialsSection.jsx
+++ b/main/src/pages/about-brand-story-credentials/components/CredentialsSection.jsx
@@ -135,7 +135,7 @@ const CredentialsSection = () => {
           </h3>
           <div className="grid lg:grid-cols-3 gap-6">
             {associations?.map((assoc, index) => (
-              <div key={index} className="bg-surface rounded-xl p-6 text-center hover:shadow-lg transition-shadow duration-300">
+              <div key={index} className="bg-gray-50 rounded-xl p-6 text-center hover:shadow-lg transition-shadow duration-300">
                 <div className="w-16 h-16 mx-auto mb-4 rounded-full overflow-hidden">
                   <Image
                     src={assoc?.logo}
@@ -160,7 +160,7 @@ const CredentialsSection = () => {
           </h3>
           <div className="space-y-6">
             {recognitions?.map((recognition, index) => (
-              <div key={index} className="bg-surface rounded-xl p-6 flex items-start space-x-4">
+              <div key={index} className="bg-gray-50 rounded-xl p-6 flex items-start space-x-4">
                 <div className="flex-shrink-0">
                   <div className="w-12 h-12 bg-yellow-100 rounded-lg flex items-center justify-center">
                     <Icon name="Trophy" size={24} color="#F59E0B" />
@@ -187,7 +187,7 @@ const CredentialsSection = () => {
           <h3 className="text-2xl font-bold text-text-primary mb-8 text-center">
             Educação Continuada
           </h3>
-          <div className="bg-surface rounded-xl p-6">
+          <div className="bg-gray-50 rounded-xl p-6">
             <div className="space-y-4">
               {continuingEducation?.map((course, index) => (
                 <div key={index} className="flex items-center justify-between p-4 bg-white rounded-lg">

--- a/main/src/pages/about-brand-story-credentials/components/NeighborhoodExpertiseSection.jsx
+++ b/main/src/pages/about-brand-story-credentials/components/NeighborhoodExpertiseSection.jsx
@@ -136,7 +136,7 @@ const NeighborhoodExpertiseSection = () => {
   ];
 
   return (
-    <section className="py-16 bg-surface">
+    <section className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl lg:text-4xl font-bold text-text-primary mb-4">

--- a/main/src/pages/about-brand-story-credentials/components/ProcessTransparencySection.jsx
+++ b/main/src/pages/about-brand-story-credentials/components/ProcessTransparencySection.jsx
@@ -145,7 +145,7 @@ const ProcessTransparencySection = () => {
                 className={`flex items-center space-x-2 px-4 py-2 rounded-lg font-medium transition-all duration-200 ${
                   activeStep === index
                     ? 'bg-primary text-white shadow-lg'
-                    : 'bg-surface text-text-secondary hover:bg-primary/10 hover:text-primary'
+                    : 'bg-gray-50 text-text-secondary hover:bg-primary/10 hover:text-primary'
                 }`}
               >
                 <span className="text-sm">{step?.step}</span>
@@ -155,7 +155,7 @@ const ProcessTransparencySection = () => {
           </div>
 
           {/* Active Step Content */}
-          <div className="bg-surface rounded-2xl p-8">
+          <div className="bg-gray-50 rounded-2xl p-8">
             <div className="grid lg:grid-cols-3 gap-8">
               {/* Step Info */}
               <div className="text-center lg:text-left">
@@ -212,7 +212,7 @@ const ProcessTransparencySection = () => {
           </h3>
           <div className="grid lg:grid-cols-3 gap-6">
             {legalRequirements?.map((category, index) => (
-              <div key={index} className="bg-surface rounded-xl p-6">
+              <div key={index} className="bg-gray-50 rounded-xl p-6">
                 <h4 className="font-semibold text-text-primary mb-4 flex items-center">
                   <Icon name="FileCheck" size={20} className="mr-2 text-primary" />
                   {category?.category}

--- a/main/src/pages/about-brand-story-credentials/components/ServicePhilosophySection.jsx
+++ b/main/src/pages/about-brand-story-credentials/components/ServicePhilosophySection.jsx
@@ -49,7 +49,7 @@ const ServicePhilosophySection = () => {
   ];
 
   return (
-    <section className="py-16 bg-surface">
+    <section className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl lg:text-4xl font-bold text-text-primary mb-4">

--- a/main/src/pages/about-brand-story-credentials/components/TimelineSection.jsx
+++ b/main/src/pages/about-brand-story-credentials/components/TimelineSection.jsx
@@ -34,7 +34,7 @@ const TimelineSection = () => {
   ];
 
   return (
-    <section className="py-16 bg-surface">
+    <section className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl lg:text-4xl font-bold text-text-primary mb-4">

--- a/main/src/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/main/src/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -46,7 +46,7 @@ const HomepagePremiumRealEstateConsultancy = () => {
         </section>
         
         {/* Expertise Section - Professional spacing */}
-        <section className="section-spacing bg-surface">
+        <section className="section-spacing bg-gray-50">
           <div className="container-responsive">
             <ExpertiseSection />
           </div>

--- a/resources/js/main/pages/about-brand-story-credentials/components/ClientSuccessSection.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/components/ClientSuccessSection.jsx
@@ -94,7 +94,7 @@ const ClientSuccessSection = () => {
   ];
 
   return (
-    <section className="py-16 bg-surface">
+    <section className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl lg:text-4xl font-bold text-text-primary mb-4">

--- a/resources/js/main/pages/about-brand-story-credentials/components/ContactSection.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/components/ContactSection.jsx
@@ -118,7 +118,8 @@ const ContactSection = () => {
                     key={index}
                     className={`p-6 rounded-xl border-2 transition-all duration-200 cursor-pointer ${
                       method?.highlight
-                        ? 'border-primary bg-primary/5 hover:bg-primary/10' :'border-border bg-surface hover:border-primary/50'
+                        ? 'border-primary bg-primary/5 hover:bg-primary/10'
+                        : 'border-border bg-gray-50 hover:border-primary/50'
                     }`}
                     onClick={method?.onClick}
                   >
@@ -152,7 +153,7 @@ const ContactSection = () => {
             </div>
 
             {/* Office Information */}
-            <div className="bg-surface rounded-xl p-6">
+            <div className="bg-gray-50 rounded-xl p-6">
               <h4 className="font-semibold text-text-primary mb-4 flex items-center">
                 <Icon name="MapPin" size={20} className="mr-2 text-primary" />
                 Nosso Escritório
@@ -171,7 +172,7 @@ const ContactSection = () => {
 
           {/* Contact Form */}
           <div>
-            <div className="bg-surface rounded-xl p-8">
+            <div className="bg-gray-50 rounded-xl p-8">
               <h3 className="text-2xl font-bold text-text-primary mb-6">
                 Solicite uma Consulta
               </h3>

--- a/resources/js/main/pages/about-brand-story-credentials/components/CredentialsSection.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/components/CredentialsSection.jsx
@@ -135,7 +135,7 @@ const CredentialsSection = () => {
           </h3>
           <div className="grid lg:grid-cols-3 gap-6">
             {associations?.map((assoc, index) => (
-              <div key={index} className="bg-surface rounded-xl p-6 text-center hover:shadow-lg transition-shadow duration-300">
+              <div key={index} className="bg-gray-50 rounded-xl p-6 text-center hover:shadow-lg transition-shadow duration-300">
                 <div className="w-16 h-16 mx-auto mb-4 rounded-full overflow-hidden">
                   <Image
                     src={assoc?.logo}
@@ -160,7 +160,7 @@ const CredentialsSection = () => {
           </h3>
           <div className="space-y-6">
             {recognitions?.map((recognition, index) => (
-              <div key={index} className="bg-surface rounded-xl p-6 flex items-start space-x-4">
+              <div key={index} className="bg-gray-50 rounded-xl p-6 flex items-start space-x-4">
                 <div className="flex-shrink-0">
                   <div className="w-12 h-12 bg-yellow-100 rounded-lg flex items-center justify-center">
                     <Icon name="Trophy" size={24} color="#F59E0B" />
@@ -187,7 +187,7 @@ const CredentialsSection = () => {
           <h3 className="text-2xl font-bold text-text-primary mb-8 text-center">
             Educação Continuada
           </h3>
-          <div className="bg-surface rounded-xl p-6">
+          <div className="bg-gray-50 rounded-xl p-6">
             <div className="space-y-4">
               {continuingEducation?.map((course, index) => (
                 <div key={index} className="flex items-center justify-between p-4 bg-white rounded-lg">

--- a/resources/js/main/pages/about-brand-story-credentials/components/NeighborhoodExpertiseSection.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/components/NeighborhoodExpertiseSection.jsx
@@ -136,7 +136,7 @@ const NeighborhoodExpertiseSection = () => {
   ];
 
   return (
-    <section className="py-16 bg-surface">
+    <section className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl lg:text-4xl font-bold text-text-primary mb-4">

--- a/resources/js/main/pages/about-brand-story-credentials/components/ProcessTransparencySection.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/components/ProcessTransparencySection.jsx
@@ -145,7 +145,7 @@ const ProcessTransparencySection = () => {
                 className={`flex items-center space-x-2 px-4 py-2 rounded-lg font-medium transition-all duration-200 ${
                   activeStep === index
                     ? 'bg-primary text-white shadow-lg'
-                    : 'bg-surface text-text-secondary hover:bg-primary/10 hover:text-primary'
+                    : 'bg-gray-50 text-text-secondary hover:bg-primary/10 hover:text-primary'
                 }`}
               >
                 <span className="text-sm">{step?.step}</span>
@@ -155,7 +155,7 @@ const ProcessTransparencySection = () => {
           </div>
 
           {/* Active Step Content */}
-          <div className="bg-surface rounded-2xl p-8">
+          <div className="bg-gray-50 rounded-2xl p-8">
             <div className="grid lg:grid-cols-3 gap-8">
               {/* Step Info */}
               <div className="text-center lg:text-left">
@@ -212,7 +212,7 @@ const ProcessTransparencySection = () => {
           </h3>
           <div className="grid lg:grid-cols-3 gap-6">
             {legalRequirements?.map((category, index) => (
-              <div key={index} className="bg-surface rounded-xl p-6">
+              <div key={index} className="bg-gray-50 rounded-xl p-6">
                 <h4 className="font-semibold text-text-primary mb-4 flex items-center">
                   <Icon name="FileCheck" size={20} className="mr-2 text-primary" />
                   {category?.category}

--- a/resources/js/main/pages/about-brand-story-credentials/components/ServicePhilosophySection.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/components/ServicePhilosophySection.jsx
@@ -49,7 +49,7 @@ const ServicePhilosophySection = () => {
   ];
 
   return (
-    <section className="py-16 bg-surface">
+    <section className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl lg:text-4xl font-bold text-text-primary mb-4">

--- a/resources/js/main/pages/about-brand-story-credentials/components/TimelineSection.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/components/TimelineSection.jsx
@@ -34,7 +34,7 @@ const TimelineSection = () => {
   ];
 
   return (
-    <section className="py-16 bg-surface">
+    <section className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl lg:text-4xl font-bold text-text-primary mb-4">

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -46,7 +46,7 @@ const HomepagePremiumRealEstateConsultancy = () => {
         </section>
         
         {/* Expertise Section - Professional spacing */}
-        <section className="section-spacing bg-surface">
+        <section className="section-spacing bg-gray-50">
           <div className="container-responsive">
             <ExpertiseSection />
           </div>


### PR DESCRIPTION
## Summary
- replace `bg-surface` with light backgrounds to prevent black blocks
- mirror updates in `main/src` page copies

## Testing
- `npm run lint` *(fails: postcss.config.js:1:1 'module' is not defined, and additional pre-existing lint errors)*
- `npm run dev` *(fails: Vite requires Node.js 20.19+)*

------
https://chatgpt.com/codex/tasks/task_b_68c32d2c14b4832ca7fffbedfa148900