### PR TITLE
Reorder homepage sections to show neighborhood map earlier

### DIFF
--- a/main/src/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/main/src/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -44,19 +44,18 @@ const HomepagePremiumRealEstateConsultancy = () => {
             <FeaturedProperties />
           </div>
         </section>
-        
-        {/* Expertise Section - Professional spacing */}
-        <section className="section-spacing bg-gray-50">
-          <div className="container-responsive">
-            <ExpertiseSection />
-          </div>
-        </section>
-        
-        
+
         {/* Neighborhood Map - Interactive section */}
         <section className="section-spacing">
           <div className="container-responsive">
             <NeighborhoodMap />
+          </div>
+        </section>
+
+        {/* Expertise Section - Professional spacing */}
+        <section className="section-spacing bg-gray-50">
+          <div className="container-responsive">
+            <ExpertiseSection />
           </div>
         </section>
       </main>

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -44,19 +44,18 @@ const HomepagePremiumRealEstateConsultancy = () => {
             <FeaturedProperties />
           </div>
         </section>
-        
-        {/* Expertise Section - Professional spacing */}
-        <section className="section-spacing bg-gray-50">
-          <div className="container-responsive">
-            <ExpertiseSection />
-          </div>
-        </section>
-        
-        
+
         {/* Neighborhood Map - Interactive section */}
         <section className="section-spacing">
           <div className="container-responsive">
             <NeighborhoodMap />
+          </div>
+        </section>
+
+        {/* Expertise Section - Professional spacing */}
+        <section className="section-spacing bg-gray-50">
+          <div className="container-responsive">
+            <ExpertiseSection />
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- Show neighborhood map immediately after featured properties on the premium real estate homepage
- Mirror the same section order in the main source version

## Testing
- `npm run lint` *(fails: 19 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c330cfa578832ca59b9341535e3a3f