### PR TITLE
feat: exibir processo transparente na homepage

### DIFF
--- a/main/src/pages/about-brand-story-credentials/index.jsx
+++ b/main/src/pages/about-brand-story-credentials/index.jsx
@@ -5,7 +5,6 @@ import HeroSection from './components/HeroSection';
 import TimelineSection from './components/TimelineSection';
 import ServicePhilosophySection from './components/ServicePhilosophySection';
 import ClientSuccessSection from './components/ClientSuccessSection';
-import ProcessTransparencySection from './components/ProcessTransparencySection';
 import ContactSection from './components/ContactSection';
 import Footer from '../../components/Footer';
 
@@ -41,7 +40,6 @@ const AboutBrandStoryCredentials = () => {
           <TimelineSection />
           <ServicePhilosophySection />
           <ClientSuccessSection />
-          <ProcessTransparencySection />
           <ContactSection />
         </main>
 

--- a/main/src/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/main/src/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -5,6 +5,7 @@ import FeaturedProperties from './components/FeaturedProperties';
 import ExpertiseSection from './components/ExpertiseSection';
 import NeighborhoodMap from './components/NeighborhoodMap';
 import WhatsAppFloat from './components/WhatsAppFloat';
+import ProcessTransparencySection from '../about-brand-story-credentials/components/ProcessTransparencySection';
 import Footer from '../../components/Footer';
 
 const HomepagePremiumRealEstateConsultancy = () => {
@@ -58,8 +59,11 @@ const HomepagePremiumRealEstateConsultancy = () => {
             <ExpertiseSection />
           </div>
         </section>
+
+        {/* Transparent Process Section */}
+        <ProcessTransparencySection />
       </main>
-      
+
       {/* Footer */}
       <Footer />
       

--- a/resources/js/main/pages/about-brand-story-credentials/index.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/index.jsx
@@ -5,7 +5,6 @@ import HeroSection from './components/HeroSection';
 import TimelineSection from './components/TimelineSection';
 import ServicePhilosophySection from './components/ServicePhilosophySection';
 import ClientSuccessSection from './components/ClientSuccessSection';
-import ProcessTransparencySection from './components/ProcessTransparencySection';
 import ContactSection from './components/ContactSection';
 import Footer from '../../components/Footer';
 
@@ -41,7 +40,6 @@ const AboutBrandStoryCredentials = () => {
           <TimelineSection />
           <ServicePhilosophySection />
           <ClientSuccessSection />
-          <ProcessTransparencySection />
           <ContactSection />
         </main>
 

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -5,6 +5,7 @@ import FeaturedProperties from './components/FeaturedProperties';
 import ExpertiseSection from './components/ExpertiseSection';
 import NeighborhoodMap from './components/NeighborhoodMap';
 import WhatsAppFloat from './components/WhatsAppFloat';
+import ProcessTransparencySection from '../about-brand-story-credentials/components/ProcessTransparencySection';
 import Footer from '../../components/Footer';
 
 const HomepagePremiumRealEstateConsultancy = () => {
@@ -58,8 +59,11 @@ const HomepagePremiumRealEstateConsultancy = () => {
             <ExpertiseSection />
           </div>
         </section>
+
+        {/* Transparent Process Section */}
+        <ProcessTransparencySection />
       </main>
-      
+
       {/* Footer */}
       <Footer />
       


### PR DESCRIPTION
## Summary
- move ProcessTransparencySection to homepage
- remove process section from about page
- ensure process section uses white background

## Testing
- `rg 'ProcessTransparencySection' -n`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68c386411260832cbbb11f7bcddcecb7