### PR TITLE
fix: keep process steps on single line

### DIFF
--- a/main/src/pages/about-brand-story-credentials/components/ProcessTransparencySection.jsx
+++ b/main/src/pages/about-brand-story-credentials/components/ProcessTransparencySection.jsx
@@ -137,12 +137,12 @@ const ProcessTransparencySection = () => {
         {/* Process Steps */}
         <div className="mb-16">
           {/* Step Navigation */}
-          <div className="flex flex-wrap justify-center gap-2 mb-8">
+          <div className="flex flex-nowrap overflow-x-auto justify-center gap-2 mb-8">
             {processSteps?.map((step, index) => (
               <button
                 key={step?.step}
                 onClick={() => setActiveStep(index)}
-                className={`flex items-center space-x-2 px-4 py-2 rounded-lg font-medium transition-all duration-200 ${
+                className={`flex items-center space-x-2 px-4 py-2 whitespace-nowrap flex-shrink-0 rounded-lg font-medium transition-all duration-200 ${
                   activeStep === index
                     ? 'bg-primary text-white shadow-lg'
                     : ' text-text-secondary hover:bg-primary/10 hover:text-primary'

--- a/resources/js/main/pages/about-brand-story-credentials/components/ProcessTransparencySection.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/components/ProcessTransparencySection.jsx
@@ -137,12 +137,12 @@ const ProcessTransparencySection = () => {
         {/* Process Steps */}
         <div className="mb-16">
           {/* Step Navigation */}
-          <div className="flex flex-wrap justify-center gap-2 mb-8">
+          <div className="flex flex-nowrap overflow-x-auto justify-center gap-2 mb-8">
             {processSteps?.map((step, index) => (
               <button
                 key={step?.step}
                 onClick={() => setActiveStep(index)}
-                className={`flex items-center space-x-2 px-4 py-2 rounded-lg font-medium transition-all duration-200 ${
+                className={`flex items-center space-x-2 px-4 py-2 whitespace-nowrap flex-shrink-0 rounded-lg font-medium transition-all duration-200 ${
                   activeStep === index
                     ? 'bg-primary text-white shadow-lg'
                     : ' text-text-secondary hover:bg-primary/10 hover:text-primary'


### PR DESCRIPTION
## Summary
- prevent process navigation from wrapping by using `flex-nowrap` and horizontal scrolling
- keep step labels intact with `whitespace-nowrap` and `flex-shrink-0`

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_b_68c38c0c81c0832c8d889c601acfb785