### PR TITLE
Fix padding and conditional image gallery in panel

### DIFF
--- a/resources/js/components/ImageGallery.tsx
+++ b/resources/js/components/ImageGallery.tsx
@@ -19,10 +19,10 @@ export default function ImageGallery({ images, onSelect }: ImageGalleryProps) {
                 <button
                     key={img.id}
                     type="button"
-                    className="overflow-hidden rounded-md border focus:outline-none focus:ring-2 focus:ring-ring"
+                    className="overflow-hidden rounded-md border focus:ring-2 focus:ring-ring focus:outline-none"
                     onClick={() => onSelect(img)}
                 >
-                    <img src={img.url} alt={img.original_name} className="h-28 w-full object-cover" />
+                    <img src={img.url} alt={img.original_name} className="aspect-square w-full object-cover" />
                 </button>
             ))}
         </div>

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -282,9 +282,7 @@ export default function Painel() {
     const editSlide = (slide: HeroSlide) => {
         setNewSlide(slide);
         setSelectedSlideImage(
-            slide.image_id && slide.image_url
-                ? { id: slide.image_id, url: slide.image_url, original_name: '', filename: '' }
-                : null,
+            slide.image_id && slide.image_url ? { id: slide.image_id, url: slide.image_url, original_name: '', filename: '' } : null,
         );
         setEditedSlideBlob(null);
         setHeroModalOpen(true);
@@ -387,7 +385,7 @@ export default function Painel() {
             <Head title="Painel" />
             <HeaderStandalone />
 
-            <div className="container-responsive section-spacing flex flex-col gap-6 pt-24">
+            <div className="container-responsive section-spacing flex flex-col gap-6 pt-6">
                 {notice && (
                     <Alert variant={notice.type === 'error' ? 'destructive' : 'default'}>
                         <AlertTitle>{notice.title}</AlertTitle>
@@ -876,20 +874,21 @@ export default function Painel() {
                                 </DialogFooter>
                             </DialogContent>
                         </Dialog>
-
-                        <ImageGallery
-                            images={images}
-                            onSelect={(img) => {
-                                if (heroModalOpen) {
-                                    setSelectedSlideImage(img);
-                                    setNewSlide((s) => ({ ...s, image_id: img.id }));
-                                } else if (featuredModalOpen) {
-                                    setSelectedFeaturedImage(img);
-                                    setNewFeatured((s) => ({ ...s, image_id: img.id }));
-                                }
-                            }}
-                        />
                     </>
+                )}
+                {(tab === 'images' || heroModalOpen || featuredModalOpen) && (
+                    <ImageGallery
+                        images={images}
+                        onSelect={(img) => {
+                            if (heroModalOpen) {
+                                setSelectedSlideImage(img);
+                                setNewSlide((s) => ({ ...s, image_id: img.id }));
+                            } else if (featuredModalOpen) {
+                                setSelectedFeaturedImage(img);
+                                setNewFeatured((s) => ({ ...s, image_id: img.id }));
+                            }
+                        }}
+                    />
                 )}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- reduce top padding in panel to tighten layout
- show image gallery only for image tab or editing modals
- standardize gallery thumbnails to square aspect

## Testing
- `npm run lint` *(fails: React hooks misused and unused vars)*
- `npm run build`
- `npm run types` *(fails: Type '(slide: HeroSlide) => void' is not assignable to type '(slide: Slide) => void')*


------
https://chatgpt.com/codex/tasks/task_b_68c39f9b0414832ca8895889d288b3bc