### PR TITLE
feat: expand image editor preview size

### DIFF
--- a/resources/js/components/ImageEditor.tsx
+++ b/resources/js/components/ImageEditor.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from 'react';
 import { useImageEditor } from '@/hooks/useImageEditor';
 import { cn } from '@/lib/utils';
+import { ReactNode } from 'react';
 import ImageFilters from './ImageFilters';
 
 interface ImageEditorProps {
@@ -10,26 +10,12 @@ interface ImageEditorProps {
     sizeClass?: string;
 }
 
-export default function ImageEditor({ src, onExport, children, sizeClass = 'w-80' }: ImageEditorProps) {
-    const {
-        imgRef,
-        containerRef,
-        zoom,
-        brightness,
-        contrast,
-        saturation,
-        setBrightness,
-        setContrast,
-        setSaturation,
-        zoomIn,
-        zoomOut,
-    } = useImageEditor({ src, onExport });
+export default function ImageEditor({ src, onExport, children, sizeClass = 'w-full max-w-[600px]' }: ImageEditorProps) {
+    const { imgRef, containerRef, zoom, brightness, contrast, saturation, setBrightness, setContrast, setSaturation, zoomIn, zoomOut } =
+        useImageEditor({ src, onExport });
 
     return (
-        <div
-            ref={containerRef}
-            className={cn('relative aspect-square overflow-hidden rounded-md mx-auto', sizeClass)}
-        >
+        <div ref={containerRef} className={cn('relative mx-auto aspect-square overflow-hidden rounded-md', sizeClass)}>
             <img
                 ref={imgRef}
                 src={src}
@@ -43,18 +29,10 @@ export default function ImageEditor({ src, onExport, children, sizeClass = 'w-80
             />
             {children}
             <div className="absolute top-4 right-4 flex gap-1">
-                <button
-                    type="button"
-                    onClick={zoomOut}
-                    className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white"
-                >
+                <button type="button" onClick={zoomOut} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
                     -
                 </button>
-                <button
-                    type="button"
-                    onClick={zoomIn}
-                    className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white"
-                >
+                <button type="button" onClick={zoomIn} className="flex h-6 w-6 items-center justify-center rounded bg-black/60 text-white">
                     +
                 </button>
             </div>

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -603,7 +603,11 @@ export default function Painel() {
                                             )}
                                         >
                                             {selectedSlideImage && (
-                                                <ImageEditor src={selectedSlideImage.url} onExport={setEditedSlideBlob}>
+                                                <ImageEditor
+                                                    src={selectedSlideImage.url}
+                                                    onExport={setEditedSlideBlob}
+                                                    sizeClass="w-full max-w-[600px]"
+                                                >
                                                     <ImagePreviewOverlay
                                                         titulo={newSlide.title}
                                                         subtitulo={newSlide.subtitle}
@@ -819,7 +823,11 @@ export default function Painel() {
                                             )}
                                         >
                                             {selectedFeaturedImage && (
-                                                <ImageEditor src={selectedFeaturedImage.url} onExport={setEditedFeaturedBlob}>
+                                                <ImageEditor
+                                                    src={selectedFeaturedImage.url}
+                                                    onExport={setEditedFeaturedBlob}
+                                                    sizeClass="w-full max-w-[600px]"
+                                                >
                                                     <ImagePreviewOverlay
                                                         titulo={newFeatured.title}
                                                         preco={newFeatured.price}


### PR DESCRIPTION
## Summary
- allow ImageEditor preview to fill modal width up to 600px
- use responsive ImageEditor size in Slide and Featured dialogs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 19 errors)*
- `npm run types` *(fails: Type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c3a9d8da10832cb644b4c12edba794