### PR TITLE
Permitir ajuste de proporção no editor de imagens

### DIFF
--- a/resources/js/components/ImageEditor.tsx
+++ b/resources/js/components/ImageEditor.tsx
@@ -8,14 +8,21 @@ interface ImageEditorProps {
     onExport?: (blob: Blob | null) => void;
     children?: ReactNode;
     sizeClass?: string;
+    aspectClass?: string;
 }
 
-export default function ImageEditor({ src, onExport, children, sizeClass = 'w-full max-w-[600px]' }: ImageEditorProps) {
+export default function ImageEditor({
+    src,
+    onExport,
+    children,
+    sizeClass = 'w-full max-w-[600px]',
+    aspectClass = 'aspect-square',
+}: ImageEditorProps) {
     const { imgRef, containerRef, zoom, brightness, contrast, saturation, setBrightness, setContrast, setSaturation, zoomIn, zoomOut } =
         useImageEditor({ src, onExport });
 
     return (
-        <div ref={containerRef} className={cn('relative mx-auto aspect-square overflow-hidden rounded-md', sizeClass)}>
+        <div ref={containerRef} className={cn('relative mx-auto overflow-hidden rounded-md', sizeClass, aspectClass)}>
             <img
                 ref={imgRef}
                 src={src}

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -606,7 +606,8 @@ export default function Painel() {
                                                 <ImageEditor
                                                     src={selectedSlideImage.url}
                                                     onExport={setEditedSlideBlob}
-                                                    sizeClass="w-full max-w-[600px]"
+                                                    sizeClass="h-full w-full"
+                                                    aspectClass="aspect-video"
                                                 >
                                                     <ImagePreviewOverlay
                                                         titulo={newSlide.title}
@@ -826,7 +827,8 @@ export default function Painel() {
                                                 <ImageEditor
                                                     src={selectedFeaturedImage.url}
                                                     onExport={setEditedFeaturedBlob}
-                                                    sizeClass="w-full max-w-[600px]"
+                                                    sizeClass="h-full w-full"
+                                                    aspectClass="aspect-video"
                                                 >
                                                     <ImagePreviewOverlay
                                                         titulo={newFeatured.title}


### PR DESCRIPTION
## Summary
- tornar aspecto configurável no ImageEditor
- aplicar proporção 16:9 nos modais de Slide e Destaque

## Testing
- `npm run lint` *(fails: 19 errors)*
- `npx eslint resources/js/components/ImageEditor.tsx resources/js/pages/painel.tsx` *(fails: 6 errors)*
- `npm run types` *(fails: type errors)*
- `npm run format:check` *(fails: code style issues)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68c419c26980832cbc92e3ec7a03fa78