### PR TITLE
refactor: drop gallery selection from admin modals

### DIFF
--- a/resources/js/components/modals/FeaturedPropertiesModal.tsx
+++ b/resources/js/components/modals/FeaturedPropertiesModal.tsx
@@ -1,5 +1,4 @@
 import ImageEditor from '@/components/ImageEditor';
-import ImageGallery from '@/components/ImageGallery';
 import FeaturedCardInfo from '@/components/FeaturedCardInfo';
 // Heart icon removed
 import { Button } from '@/components/ui/button';
@@ -47,18 +46,16 @@ export interface Notice {
 interface Props {
     open: boolean;
     onOpenChange: (open: boolean) => void;
-    images: Image[];
     featured: FeaturedProperty[];
     onRefreshFeatured: () => Promise<void>;
     onNotice?: (n: Notice) => void;
-    onUploadImages: (files: FileList | null) => Promise<boolean>;
+    onUploadImages: (files: FileList | null) => Promise<Image[]>;
     uploadingImages?: boolean;
 }
 
 export default function FeaturedPropertiesModal({
     open,
     onOpenChange,
-    images,
     featured,
     onRefreshFeatured,
     onNotice,
@@ -70,18 +67,29 @@ export default function FeaturedPropertiesModal({
     const [form, setForm] = useState<Partial<FeaturedProperty>>({ features: [] });
     const [featureInput, setFeatureInput] = useState('');
     const [selectedImage, setSelectedImage] = useState<Image | null>(null);
-    const [imagePickerOpen, setImagePickerOpen] = useState(false);
-    const [imagePickerFor, setImagePickerFor] = useState<'main' | 'gallery' | null>(null);
     const [gallery, setGallery] = useState<Image[]>([]);
     const mainUploadInputRef = useRef<HTMLInputElement | null>(null);
     const galleryUploadInputRef = useRef<HTMLInputElement | null>(null);
 
-    const handleUploadChange = async (event: ChangeEvent<HTMLInputElement>, target: 'main' | 'gallery') => {
-        const success = await onUploadImages(event.target.files);
+    const handleMainUploadChange = async (event: ChangeEvent<HTMLInputElement>) => {
+        const uploaded = await onUploadImages(event.target.files);
         event.target.value = '';
-        if (success) {
-            setImagePickerFor(target);
-            setImagePickerOpen(true);
+        if (uploaded.length > 0) {
+            const [first] = uploaded;
+            setSelectedImage(first);
+            setForm((s) => ({ ...s, image_id: first.id }));
+        }
+    };
+
+    const handleGalleryUploadChange = async (event: ChangeEvent<HTMLInputElement>) => {
+        const uploaded = await onUploadImages(event.target.files);
+        event.target.value = '';
+        if (uploaded.length > 0) {
+            setGallery((prev) => {
+                const existingIds = new Set(prev.map((img) => img.id));
+                const additions = uploaded.filter((img) => !existingIds.has(img.id));
+                return [...prev, ...additions];
+            });
         }
     };
 
@@ -281,18 +289,9 @@ export default function FeaturedPropertiesModal({
                     </div>
                     <div>
                         <Label>Imagem</Label>
-                        <p className="mt-2 text-sm text-muted-foreground">Selecione uma imagem clicando no botão abaixo.</p>
-                        <Button
-                            type="button"
-                            variant="default"
-                            className="mt-2 w-auto bg-black text-white hover:bg-black/90"
-                            onClick={() => {
-                                setImagePickerFor('main');
-                                setImagePickerOpen(true);
-                            }}
-                        >
-                            Selecionar da galeria
-                        </Button>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                            Envie a imagem principal do destaque utilizando o botão abaixo.
+                        </p>
                         <Button
                             type="button"
                             variant="secondary"
@@ -300,7 +299,7 @@ export default function FeaturedPropertiesModal({
                             onClick={() => mainUploadInputRef.current?.click()}
                             disabled={uploadingImages}
                         >
-                            {uploadingImages ? 'Enviando…' : 'Enviar novas imagens'}
+                            {uploadingImages ? 'Enviando…' : 'Enviar imagem principal'}
                         </Button>
                         <input
                             ref={mainUploadInputRef}
@@ -308,7 +307,7 @@ export default function FeaturedPropertiesModal({
                             multiple
                             accept="image/*"
                             className="hidden"
-                            onChange={(event) => handleUploadChange(event, 'main')}
+                            onChange={handleMainUploadChange}
                         />
                         <div className={cn('mt-4 w-full', !selectedImage && 'border-2 border-dashed')}>
                             {selectedImage && (
@@ -371,23 +370,12 @@ export default function FeaturedPropertiesModal({
                         <div className="mt-3 flex flex-wrap gap-2">
                             <Button
                                 type="button"
-                                variant="outline"
-                                className="w-auto"
-                                onClick={() => {
-                                    setImagePickerFor('gallery');
-                                    setImagePickerOpen(true);
-                                }}
-                            >
-                                Selecionar da galeria
-                            </Button>
-                            <Button
-                                type="button"
                                 variant="secondary"
                                 className="w-auto"
                                 onClick={() => galleryUploadInputRef.current?.click()}
                                 disabled={uploadingImages}
                             >
-                                {uploadingImages ? 'Enviando…' : 'Enviar novas imagens'}
+                                {uploadingImages ? 'Enviando…' : 'Enviar imagens da galeria'}
                             </Button>
                         </div>
                         <input
@@ -396,7 +384,7 @@ export default function FeaturedPropertiesModal({
                             multiple
                             accept="image/*"
                             className="hidden"
-                            onChange={(event) => handleUploadChange(event, 'gallery')}
+                            onChange={handleGalleryUploadChange}
                         />
                     </div>
                     <div className="flex items-end gap-2">
@@ -411,43 +399,6 @@ export default function FeaturedPropertiesModal({
                     </Button>
                 </DialogFooter>
 
-                {/* Image Picker (principal ou galeria) */}
-                <Dialog open={imagePickerOpen} onOpenChange={setImagePickerOpen}>
-                    <DialogContent aria-describedby="image-picker-featured-desc">
-                        <DialogHeader>
-                            <DialogTitle>Selecionar imagem</DialogTitle>
-                        </DialogHeader>
-                        <DialogDescription id="image-picker-featured-desc">
-                            {imagePickerFor === 'gallery' ? 'Escolha uma ou mais imagens na lista abaixo' : 'Escolha uma imagem na lista abaixo'}
-                        </DialogDescription>
-                        <ImageGallery
-                            images={images}
-                            multiple={imagePickerFor === 'gallery'}
-                            selected={imagePickerFor === 'gallery' ? gallery.map((g) => g.id) : selectedImage?.id ? [selectedImage.id] : []}
-                            onChangeSelected={(_ids, imgs) => {
-                                if (imagePickerFor === 'gallery') {
-                                    setGallery(imgs);
-                                } else {
-                                    setSelectedImage(imgs[0] ?? null);
-                                    setForm((s) => ({ ...s, image_id: imgs[0]?.id ?? s.image_id }));
-                                    setImagePickerOpen(false);
-                                }
-                            }}
-                            onSelect={(img) => {
-                                if (imagePickerFor === 'gallery') {
-                                    // fallback: toggle handled by onChangeSelected
-                                } else {
-                                    setSelectedImage(img);
-                                    setForm((s) => ({ ...s, image_id: img.id }));
-                                    setImagePickerOpen(false);
-                                }
-                            }}
-                            showFooter={imagePickerFor === 'gallery'}
-                            onConfirm={() => setImagePickerOpen(false)}
-                            confirmLabel="Concluir"
-                        />
-                    </DialogContent>
-                </Dialog>
             </DialogContent>
         </Dialog>
     );

--- a/resources/js/components/modals/HeroSlidesModal.tsx
+++ b/resources/js/components/modals/HeroSlidesModal.tsx
@@ -1,5 +1,4 @@
 import ImageEditor from '@/components/ImageEditor';
-import ImageGallery from '@/components/ImageGallery';
 import ImagePreviewOverlay from '@/components/ImagePreviewOverlay';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -8,7 +7,7 @@ import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 import { apiFetch } from '@/lib/api';
 import * as HeroActions from '@/actions/App/Http/Controllers/HeroSlideController';
-import { useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
 
 type Image = {
     id: number;
@@ -44,20 +43,30 @@ export interface Notice {
 interface Props {
     open: boolean;
     onOpenChange: (open: boolean) => void;
-    images: Image[];
     slides: HeroSlide[];
     onRefreshSlides: () => Promise<void>;
     onNotice?: (n: Notice) => void;
     editingSlide?: HeroSlide | null;
+    onUploadImages: (files: FileList | null) => Promise<Image[]>;
+    uploadingImages?: boolean;
 }
 
-export default function HeroSlidesModal({ open, onOpenChange, images, slides, onRefreshSlides, onNotice, editingSlide }: Props) {
+export default function HeroSlidesModal({
+    open,
+    onOpenChange,
+    slides,
+    onRefreshSlides,
+    onNotice,
+    editingSlide,
+    onUploadImages,
+    uploadingImages = false,
+}: Props) {
     const [creating, setCreating] = useState(false);
     const [slidesLoading, setSlidesLoading] = useState(false);
 
     const [form, setForm] = useState<Partial<HeroSlide>>({});
     const [selectedImage, setSelectedImage] = useState<Image | null>(null);
-    const [imagePickerOpen, setImagePickerOpen] = useState(false);
+    const uploadInputRef = useRef<HTMLInputElement | null>(null);
 
     // Prefill when editing
     useEffect(() => {
@@ -75,6 +84,16 @@ export default function HeroSlidesModal({ open, onOpenChange, images, slides, on
             setSelectedImage(null);
         }
     }, [open, editingSlide]);
+
+    const handleUploadChange = async (event: ChangeEvent<HTMLInputElement>) => {
+        const uploaded = await onUploadImages(event.target.files);
+        event.target.value = '';
+        if (uploaded.length > 0) {
+            const [first] = uploaded;
+            setSelectedImage(first);
+            setForm((s) => ({ ...s, image_id: first.id }));
+        }
+    };
 
     const submit = async () => {
         if (!selectedImage?.id || !form.title || !form.price) {
@@ -233,10 +252,25 @@ export default function HeroSlidesModal({ open, onOpenChange, images, slides, on
                     </div>
                     <div>
                         <Label>Imagem</Label>
-                        <p className="mt-2 text-sm text-muted-foreground">Selecione uma imagem clicando no botão abaixo.</p>
-                        <Button type="button" variant="default" className="mt-2 w-auto bg-black text-white hover:bg-black/90" onClick={() => setImagePickerOpen(true)}>
-                            Selecionar da galeria
+                        <p className="mt-2 text-sm text-muted-foreground">
+                            Envie uma imagem utilizando o botão abaixo.
+                        </p>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            className="mt-2 w-auto"
+                            onClick={() => uploadInputRef.current?.click()}
+                            disabled={uploadingImages}
+                        >
+                            {uploadingImages ? 'Enviando…' : 'Enviar imagem'}
                         </Button>
+                        <input
+                            ref={uploadInputRef}
+                            type="file"
+                            accept="image/*"
+                            className="hidden"
+                            onChange={handleUploadChange}
+                        />
                         <div className={cn('mt-4 w-full rounded-2xl shadow-lg overflow-hidden', !selectedImage && 'border-2 border-dashed')}>
                             {selectedImage && (
                                 <ImageEditor src={selectedImage.url} sizeClass="w-full" aspect="video">
@@ -265,23 +299,6 @@ export default function HeroSlidesModal({ open, onOpenChange, images, slides, on
                     </Button>
                 </DialogFooter>
 
-                {/* Image Picker */}
-                <Dialog open={imagePickerOpen} onOpenChange={setImagePickerOpen}>
-                    <DialogContent aria-describedby="image-picker-slide-desc">
-                        <DialogHeader>
-                            <DialogTitle>Selecionar imagem</DialogTitle>
-                        </DialogHeader>
-                        <DialogDescription id="image-picker-slide-desc">Escolha uma imagem na lista abaixo</DialogDescription>
-                        <ImageGallery
-                            images={images}
-                            onSelect={(img) => {
-                                setSelectedImage(img);
-                                setForm((s) => ({ ...s, image_id: img.id }));
-                                setImagePickerOpen(false);
-                            }}
-                        />
-                    </DialogContent>
-                </Dialog>
             </DialogContent>
         </Dialog>
     );

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -1,5 +1,4 @@
 import ImageEditor from '@/components/ImageEditor';
-import ImageGallery from '@/components/ImageGallery';
 import ImagePreviewOverlay from '@/components/ImagePreviewOverlay';
 import FeaturedCardInfo from '@/components/FeaturedCardInfo';
 // import { Heart } from 'lucide-react';
@@ -69,12 +68,10 @@ type FeaturedProperty = {
 
 export default function Painel() {
     // Imagens
-    const [images, setImages] = useState<Image[]>([]);
     const [imagesUploading, setImagesUploading] = useState(false);
 
     // Slides
     const [slides, setSlides] = useState<HeroSlide[]>([]);
-    const [, setImagesLoading] = useState(false);
     const [slidesLoading, setSlidesLoading] = useState(false);
     // Local state for legacy slide modal
     const [creatingSlide, setCreatingSlide] = useState(false);
@@ -90,8 +87,6 @@ export default function Painel() {
 
     const [heroModalOpen, setHeroModalOpen] = useState(false);
     const [featuredModalOpen, setFeaturedModalOpen] = useState(false);
-    const [imagePickerOpen, setImagePickerOpen] = useState(false);
-    const [imagePickerFor, setImagePickerFor] = useState<'slide' | null>(null);
     const heroUploadInputRef = useRef<HTMLInputElement | null>(null);
 
     // Notices
@@ -135,19 +130,7 @@ export default function Painel() {
     };
 
     const refreshAll = async () => {
-        await Promise.all([refreshImages(), refreshSlides(), refreshFeatured()]);
-    };
-
-    const refreshImages = async () => {
-        setImagesLoading(true);
-        try {
-            const data = await apiFetch<Image[]>(ImageActions.index());
-            setImages(data);
-        } catch (e) {
-            setNotice({ type: 'error', title: 'Falha ao carregar imagens', message: e instanceof Error ? e.message : String(e) });
-        } finally {
-            setImagesLoading(false);
-        }
+        await Promise.all([refreshSlides(), refreshFeatured()]);
     };
 
     const refreshSlides = async () => {
@@ -171,34 +154,34 @@ export default function Painel() {
         }
     };
 
-    const uploadImages = async (fileList: FileList | null) => {
-        if (!fileList || fileList.length === 0) return false;
+    const uploadImages = async (fileList: FileList | null): Promise<Image[]> => {
+        if (!fileList || fileList.length === 0) return [];
         const fd = new FormData();
         Array.from(fileList).forEach((f) => fd.append('images[]', f));
         setImagesUploading(true);
         try {
-            await apiFetch(ImageActions.store(), { body: fd });
-            await refreshImages();
+            const uploaded = await apiFetch<Image[]>(ImageActions.store(), { body: fd });
             setNotice({ type: 'success', title: 'Imagens enviadas com sucesso' });
-            return true;
+            return uploaded;
         } catch (e) {
             setNotice({
                 type: 'error',
                 title: 'Falha ao enviar imagens',
                 message: e instanceof Error ? e.message : String(e),
             });
-            return false;
+            return [];
         } finally {
             setImagesUploading(false);
         }
     };
 
     const handleHeroUploadChange = async (event: ChangeEvent<HTMLInputElement>) => {
-        const success = await uploadImages(event.target.files);
+        const uploaded = await uploadImages(event.target.files);
         event.target.value = '';
-        if (success) {
-            setImagePickerFor('slide');
-            setImagePickerOpen(true);
+        if (uploaded.length > 0) {
+            const [first] = uploaded;
+            setSelectedSlideImage(first);
+            setNewSlide((s) => ({ ...s, image_id: first.id }));
         }
     };
 
@@ -257,8 +240,11 @@ export default function Painel() {
         const fullSlide = slides.find((item) => item.id === slide.id) ?? null;
         if (fullSlide) {
             setNewSlide(fullSlide);
-            const relatedImage = images.find((img) => img.id === fullSlide.image_id) ?? null;
-            setSelectedSlideImage(relatedImage);
+            setSelectedSlideImage(
+                fullSlide.image_id && fullSlide.image_url
+                    ? { id: fullSlide.image_id, url: fullSlide.image_url, original_name: '', filename: '' }
+                    : null,
+            );
         } else {
             setNewSlide({
                 id: slide.id,
@@ -267,7 +253,11 @@ export default function Painel() {
                 image_id: slide.image_id,
                 is_published: slide.is_published,
             });
-            setSelectedSlideImage(slide.image_id ? images.find((img) => img.id === slide.image_id) ?? null : null);
+            setSelectedSlideImage(
+                slide.image_id && slide.image_url
+                    ? { id: slide.image_id, url: slide.image_url, original_name: '', filename: '' }
+                    : null,
+            );
         }
         setHeroModalOpen(true);
     };
@@ -606,18 +596,7 @@ export default function Painel() {
                                     </div>
                                     <div>
                                         <Label>Imagem</Label>
-                                        <p className="mt-2 text-sm text-muted-foreground">Selecione uma imagem clicando no botão abaixo.</p>
-                                        <Button
-                                            type="button"
-                                            variant="default"
-                                            className="mt-2 w-auto bg-black text-white hover:bg-black/90"
-                                            onClick={() => {
-                                                setImagePickerFor('slide');
-                                                setImagePickerOpen(true);
-                                            }}
-                                        >
-                                            Selecionar da galeria
-                                        </Button>
+                                        <p className="mt-2 text-sm text-muted-foreground">Envie uma imagem utilizando o botão abaixo.</p>
                                         <Button
                                             type="button"
                                             variant="secondary"
@@ -625,7 +604,7 @@ export default function Painel() {
                                             onClick={() => heroUploadInputRef.current?.click()}
                                             disabled={imagesUploading}
                                         >
-                                            {imagesUploading ? 'Enviando…' : 'Enviar novas imagens'}
+                                            {imagesUploading ? 'Enviando…' : 'Enviar imagem'}
                                         </Button>
                                         <input
                                             ref={heroUploadInputRef}
@@ -673,7 +652,6 @@ export default function Painel() {
                         <FeaturedPropertiesModal
                             open={featuredModalOpen}
                             onOpenChange={setFeaturedModalOpen}
-                            images={images}
                             featured={featured}
                             onRefreshFeatured={refreshFeatured}
                             onNotice={(n) => setNotice(n)}
@@ -681,33 +659,6 @@ export default function Painel() {
                             uploadingImages={imagesUploading}
                         />
                 </>
-                {/* Dialogo para selecionar imagem para slides */}
-                <Dialog
-                    open={imagePickerOpen && imagePickerFor === 'slide'}
-                    onOpenChange={(o) => {
-                        if (!o) {
-                            setImagePickerOpen(false);
-                            setImagePickerFor(null);
-                        }
-                    }}
-                >
-                    <DialogContent aria-describedby="image-picker-slide-desc">
-                        <DialogHeader>
-                            <DialogTitle>Selecionar imagem</DialogTitle>
-                        </DialogHeader>
-                        {/* DialogDescription é necessário para acessibilidade */}
-                        <DialogDescription id="image-picker-slide-desc">Escolha uma imagem na lista abaixo</DialogDescription>
-                        <ImageGallery
-                            images={images}
-                            onSelect={(img) => {
-                                setSelectedSlideImage(img);
-                                setNewSlide((s) => ({ ...s, image_id: img.id }));
-                                setImagePickerOpen(false);
-                                setImagePickerFor(null);
-                            }}
-                        />
-                    </DialogContent>
-                </Dialog>
 
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the gallery picker from hero and featured modals in favor of direct image uploads with inline file inputs
- streamline panel flow to upload images on demand and auto-select the freshly uploaded assets
- adjust featured gallery handling to build its list from new uploads only

## Testing
- npm run types

------
https://chatgpt.com/codex/tasks/task_b_68d49098606c832cba9c75f4ec833dea