### PR TITLE
Improve featured properties publish button

### DIFF
--- a/resources/js/components/modals/FeaturedPropertiesModal.tsx
+++ b/resources/js/components/modals/FeaturedPropertiesModal.tsx
@@ -481,15 +481,18 @@ export default function FeaturedPropertiesModal({
                             <p className="mt-4 text-sm text-muted-foreground">Nenhuma imagem selecionada.</p>
                         )}
                     </div>
-                    <div className="flex items-end gap-2">
-                        <Button className="w-auto" onClick={submit} disabled={creating} title="Adicionar Destaque">
-                            {creating ? '…' : '+'}
-                        </Button>
-                    </div>
                 </div>
                 <DialogFooter>
                     <Button className="w-auto" variant="secondary" onClick={() => onOpenChange(false)}>
                         Fechar
+                    </Button>
+                    <Button
+                        className="w-auto"
+                        onClick={submit}
+                        disabled={creating}
+                        title="Publicar destaque"
+                    >
+                        {creating ? 'Publicando…' : 'Publicar'}
                     </Button>
                 </DialogFooter>
 


### PR DESCRIPTION
## Summary
- replace the generic plus icon publish action with a "Publicar" button
- move the publish button into the dialog footer next to the close button for better clarity
- show a "Publicando…" label while the publish request is in progress

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files such as main/tailwind.config.js and useGoogleAnalytics.js)*

------
https://chatgpt.com/codex/tasks/task_b_68d49c1853a0832ca2a44fbdb27cc856