### PR TITLE
Atualiza botões de modais com fundo preto

### DIFF
--- a/resources/js/components/delete-user.tsx
+++ b/resources/js/components/delete-user.tsx
@@ -72,7 +72,11 @@ export default function DeleteUser() {
 
                                     <DialogFooter className="gap-2">
                                         <DialogClose asChild>
-                                            <Button variant="secondary" onClick={() => resetAndClearErrors()}>
+                                            <Button
+                                                variant="secondary"
+                                                className="bg-black text-white hover:bg-black/80"
+                                                onClick={() => resetAndClearErrors()}
+                                            >
                                                 Cancel
                                             </Button>
                                         </DialogClose>

--- a/resources/js/components/modals/FeaturedPropertiesModal.tsx
+++ b/resources/js/components/modals/FeaturedPropertiesModal.tsx
@@ -351,7 +351,7 @@ export default function FeaturedPropertiesModal({
                             <Button
                                 type="button"
                                 variant="secondary"
-                                className="w-auto"
+                                className="w-auto bg-black text-white hover:bg-black/80"
                                 onClick={() => {
                                     const v = featureInput.trim();
                                     if (!v) return;
@@ -370,7 +370,7 @@ export default function FeaturedPropertiesModal({
                                         {f}
                                         <button
                                             type="button"
-                                            className="text-muted-foreground hover:text-foreground"
+                                            className="rounded-full bg-black px-1 text-white hover:bg-black/80"
                                             onClick={() => setForm((s) => ({ ...s, features: (s.features ?? []).filter((_, i) => i !== idx) }))}
                                         >
                                             ×
@@ -388,7 +388,7 @@ export default function FeaturedPropertiesModal({
                         <Button
                             type="button"
                             variant="secondary"
-                            className="mt-2 w-auto"
+                            className="mt-2 w-auto bg-black text-white hover:bg-black/80"
                             onClick={() => uploadInputRef.current?.click()}
                             disabled={uploadingImages}
                         >
@@ -494,7 +494,7 @@ export default function FeaturedPropertiesModal({
                     </div>
                 </div>
                 <DialogFooter>
-                    <Button className="w-auto" variant="secondary" onClick={() => onOpenChange(false)}>
+                    <Button className="w-auto bg-black text-white hover:bg-black/80" variant="secondary" onClick={() => onOpenChange(false)}>
                         Fechar
                     </Button>
                     <Button

--- a/resources/js/components/modals/HeroSlidesModal.tsx
+++ b/resources/js/components/modals/HeroSlidesModal.tsx
@@ -146,7 +146,7 @@ export default function HeroSlidesModal({
                         <div className="flex items-center gap-2 text-sm text-muted-foreground">
                             <span>{slidesLoading ? 'Carregando…' : `${slidesCount} itens`}</span>
                             <Button
-                                className="w-auto hidden"
+                                className="hidden w-auto bg-black text-white hover:bg-black/80"
                                 variant="secondary"
                                 onClick={async () => {
                                     setSlidesLoading(true);
@@ -258,7 +258,7 @@ export default function HeroSlidesModal({
                         <Button
                             type="button"
                             variant="secondary"
-                            className="mt-2 w-auto"
+                            className="mt-2 w-auto bg-black text-white hover:bg-black/80"
                             onClick={() => uploadInputRef.current?.click()}
                             disabled={uploadingImages}
                         >
@@ -294,7 +294,7 @@ export default function HeroSlidesModal({
                     </div>
                 </div>
                 <DialogFooter>
-                    <Button className="w-auto" variant="secondary" onClick={() => onOpenChange(false)}>
+                    <Button className="w-auto bg-black text-white hover:bg-black/80" variant="secondary" onClick={() => onOpenChange(false)}>
                         Fechar
                     </Button>
                 </DialogFooter>

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -493,7 +493,7 @@ export default function Painel() {
                                         <div className="flex items-center gap-2 text-sm text-muted-foreground">
                                             <span>{slidesLoading ? 'Carregando…' : `${slides.length} itens`}</span>
                                             <Button
-                                                className="w-auto hidden"
+                                                className="hidden w-auto bg-black text-white hover:bg-black/80"
                                                 variant="secondary"
                                                 onClick={refreshSlides}
                                                 disabled={slidesLoading}
@@ -600,7 +600,7 @@ export default function Painel() {
                                         <Button
                                             type="button"
                                             variant="secondary"
-                                            className="mt-2 w-auto"
+                                            className="mt-2 w-auto bg-black text-white hover:bg-black/80"
                                             onClick={() => heroUploadInputRef.current?.click()}
                                             disabled={imagesUploading}
                                         >
@@ -642,7 +642,7 @@ export default function Painel() {
                                     </div>
                                 </div>
                                 <DialogFooter>
-                                    <Button className="w-auto" variant="secondary" onClick={() => setHeroModalOpen(false)}>
+                                    <Button className="w-auto bg-black text-white hover:bg-black/80" variant="secondary" onClick={() => setHeroModalOpen(false)}>
                                         Fechar
                                     </Button>
                                 </DialogFooter>


### PR DESCRIPTION
## Summary
- ajusta botões secundários nos modais para fundo preto com texto branco
- aplica o mesmo padrão no painel administrativo e no cancelamento da exclusão de conta
- garante que ações auxiliares dentro dos modais, como remoção de features, também tenham contraste adequado

## Testing
- `npm run lint` *(fails: lint aponta problemas pré-existentes em arquivos não relacionados, como useGoogleAnalytics.js e configurações do projeto)*

------
https://chatgpt.com/codex/tasks/task_b_68d4a4b42434832c8f8c71e5fc040532