### PR TITLE
Support featured property gallery images

### DIFF
--- a/app/Http/Controllers/FeaturedPropertyController.php
+++ b/app/Http/Controllers/FeaturedPropertyController.php
@@ -10,7 +10,7 @@ class FeaturedPropertyController extends Controller
 {
     public function publicIndex(): JsonResponse
     {
-        $items = FeaturedProperty::with('image')
+        $items = FeaturedProperty::with(['image', 'galleryImages.image'])
             ->where('is_published', true)
             ->orderBy('position')
             ->orderBy('id')
@@ -20,7 +20,7 @@ class FeaturedPropertyController extends Controller
 
     public function index(): JsonResponse
     {
-        $items = FeaturedProperty::with('image')
+        $items = FeaturedProperty::with(['image', 'galleryImages.image'])
             ->orderBy('position')
             ->orderBy('id')
             ->get();
@@ -43,12 +43,15 @@ class FeaturedPropertyController extends Controller
             'price_range'  => ['nullable', 'string', 'max:50'],
             'is_new'       => ['nullable', 'boolean'],
             'is_published' => ['nullable', 'boolean'],
+            'gallery_image_ids' => ['nullable', 'array'],
+            'gallery_image_ids.*' => ['integer', 'exists:images,id'],
         ]);
 
         $data['features'] = $data['features'] ?? [];
         $data['position'] = (int) FeaturedProperty::max('position') + 1;
         $item = FeaturedProperty::create($data);
-        $item->load('image');
+        $this->syncGalleryImages($item, $request->input('gallery_image_ids', []));
+        $item->load('image', 'galleryImages.image');
         return response()->json($item, 201);
     }
 
@@ -68,9 +71,14 @@ class FeaturedPropertyController extends Controller
             'price_range'  => ['nullable', 'string', 'max:50'],
             'is_new'       => ['nullable', 'boolean'],
             'is_published' => ['nullable', 'boolean'],
+            'gallery_image_ids' => ['nullable', 'array'],
+            'gallery_image_ids.*' => ['integer', 'exists:images,id'],
         ]);
         $featuredProperty->update($data);
-        $featuredProperty->load('image');
+        if ($request->has('gallery_image_ids')) {
+            $this->syncGalleryImages($featuredProperty, $request->input('gallery_image_ids', []));
+        }
+        $featuredProperty->load('image', 'galleryImages.image');
         return response()->json($featuredProperty);
     }
 
@@ -97,6 +105,26 @@ class FeaturedPropertyController extends Controller
             FeaturedProperty::where('id', $id)->update(['position' => $idx + 1]);
         }
         return response()->json(['message' => 'Reordered']);
+    }
+
+    /**
+     * @param  int[]  $galleryImageIds
+     */
+    protected function syncGalleryImages(FeaturedProperty $featuredProperty, array $galleryImageIds): void
+    {
+        $featuredProperty->galleryImages()->delete();
+
+        $position = 1;
+        foreach ($galleryImageIds as $imageId) {
+            if (!is_int($imageId) && !ctype_digit((string) $imageId)) {
+                continue;
+            }
+
+            $featuredProperty->galleryImages()->create([
+                'image_id' => (int) $imageId,
+                'position' => $position++,
+            ]);
+        }
     }
 }
 

--- a/app/Models/FeaturedProperty.php
+++ b/app/Models/FeaturedProperty.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Storage;
 
 class FeaturedProperty extends Model
@@ -26,11 +27,16 @@ class FeaturedProperty extends Model
         'features' => '[]',
     ];
 
-    protected $appends = ['image_url'];
+    protected $appends = ['image_url', 'gallery'];
 
     public function image(): BelongsTo
     {
         return $this->belongsTo(Image::class);
+    }
+
+    public function galleryImages(): HasMany
+    {
+        return $this->hasMany(FeaturedPropertyGalleryImage::class)->orderBy('position');
     }
 
     public function getImageUrlAttribute(): ?string
@@ -41,5 +47,28 @@ class FeaturedProperty extends Model
         $image = $this->getRelation('image');
         if (!$image) return null;
         return Storage::disk($image->disk)->url($image->path);
+    }
+
+    public function getGalleryAttribute(): array
+    {
+        $gallery = [];
+
+        $primary = $this->image_url;
+        if ($primary) {
+            $gallery[] = $primary;
+        }
+
+        $galleryImages = $this->relationLoaded('galleryImages')
+            ? $this->galleryImages
+            : $this->galleryImages()->with('image')->get();
+
+        foreach ($galleryImages as $galleryImage) {
+            $url = $galleryImage->image?->url;
+            if ($url && !in_array($url, $gallery, true)) {
+                $gallery[] = $url;
+            }
+        }
+
+        return $gallery;
     }
 }

--- a/app/Models/FeaturedPropertyGalleryImage.php
+++ b/app/Models/FeaturedPropertyGalleryImage.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FeaturedPropertyGalleryImage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'featured_property_id',
+        'image_id',
+        'position',
+    ];
+
+    public function featuredProperty(): BelongsTo
+    {
+        return $this->belongsTo(FeaturedProperty::class);
+    }
+
+    public function image(): BelongsTo
+    {
+        return $this->belongsTo(Image::class);
+    }
+}

--- a/database/migrations/2025_09_07_030000_create_featured_property_gallery_images_table.php
+++ b/database/migrations/2025_09_07_030000_create_featured_property_gallery_images_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('featured_property_gallery_images', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('featured_property_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('image_id')->constrained('images')->cascadeOnDelete();
+            $table->unsignedInteger('position')->default(0);
+            $table->timestamps();
+
+            $table->unique(['featured_property_id', 'image_id']);
+            $table->index(['featured_property_id', 'position']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('featured_property_gallery_images');
+    }
+};


### PR DESCRIPTION
## Summary
- add a featured property gallery pivot table and model to persist additional images
- expose gallery URLs from FeaturedProperty via an accessor and include them in public/admin listings
- accept gallery image IDs on create/update to sync gallery records alongside the primary image

## Testing
- `php artisan test` *(fails: application key is missing in the test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d4aad435e0832c9b3de3d1ed98efd9