### PR TITLE
Ajustar acionadores dos modais do painel

### DIFF
--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -339,19 +339,20 @@ export default function Painel() {
                 <>
                         {/* Seção: Hero Slides */}
                         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-                            <div className="flex items-center gap-2">
-                                <h2 className="text-lg font-semibold">Hero Slides</h2>
-                                <Button
-                                    className="w-auto"
-                                    onClick={() => {
-                                        setNewSlide({});
-                                        setSelectedSlideImage(null);
-                                        setHeroModalOpen(true);
-                                    }}
-                                >
-                                    Novo Slide
-                                </Button>
-                            </div>
+                            <button
+                                type="button"
+                                className="inline-flex items-center gap-2 text-left text-lg font-semibold text-foreground transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                                onClick={() => {
+                                    setNewSlide({});
+                                    setSelectedSlideImage(null);
+                                    setHeroModalOpen(true);
+                                }}
+                            >
+                                <span aria-hidden="true" className="text-xl leading-none">
+                                    +
+                                </span>
+                                <span>Hero Slides</span>
+                            </button>
                             {/* Botão de atualizar removido */}
                         </div>
 
@@ -396,12 +397,18 @@ export default function Painel() {
 
                         {/* Seção: Imóveis em Destaque */}
                         <div className="mt-10 mb-2 flex flex-wrap items-center justify-between gap-2">
-                            <div className="flex items-center gap-2">
-                                <h2 className="text-lg font-semibold">Imóveis em Destaque</h2>
-                                <Button className="w-auto" onClick={() => setFeaturedModalOpen(true)}>
-                                    Novo Destaque
-                                </Button>
-                            </div>
+                            <button
+                                type="button"
+                                className="inline-flex items-center gap-2 text-left text-lg font-semibold text-foreground transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                                onClick={() => {
+                                    setFeaturedModalOpen(true);
+                                }}
+                            >
+                                <span aria-hidden="true" className="text-xl leading-none">
+                                    +
+                                </span>
+                                <span>Imóveis em Destaque</span>
+                            </button>
                             {/* Botão de atualizar removido */}
                         </div>
                         <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
## Resumo
- transformar os cabeçalhos de Hero Slides e Imóveis em Destaque em controles únicos com o símbolo “+” à esquerda
- garantir que cada cabeçalho acione apenas o modal correspondente ao ser clicado

## Testes
- npm run lint *(falhou: projeto já contém erros de lint não relacionados)*

------
https://chatgpt.com/codex/tasks/task_b_68d4c2e7c4f8832ca12d868cc5dc5df2