### PR TITLE
Atualiza rótulo do botão de publicação dos hero slides

### DIFF
--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -688,8 +688,19 @@ export default function Painel() {
                                         </div>
                                     </div>
                                     <div className="flex items-end gap-2">
-                                        <Button className="w-auto" onClick={submitSlide} disabled={creatingSlide} title="Adicionar Slide">
-                                            {creatingSlide ? '…' : '+'}
+                                        <Button
+                                            className="w-auto"
+                                            onClick={submitSlide}
+                                            disabled={creatingSlide}
+                                            title={newSlide.id ? 'Atualizar slide' : 'Publicar slide'}
+                                        >
+                                            {newSlide.id
+                                                ? creatingSlide
+                                                    ? 'Atualizando…'
+                                                    : 'Atualizar'
+                                                : creatingSlide
+                                                  ? 'Publicando…'
+                                                  : 'Publicar'}
                                         </Button>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- exibe o rótulo "Publicar" (ou "Atualizar") no botão de envio do modal de hero slides para corresponder aos demais modais e inclui estados de carregamento textuais

## Testing
- npm run lint *(fails: existing lint violations in arquivos não relacionados)*

------
https://chatgpt.com/codex/tasks/task_b_68d4ccd73388832cbc906c34f7b18b14