### PR TITLE
Align hero slides modal footer actions

### DIFF
--- a/resources/js/components/modals/HeroSlidesModal.tsx
+++ b/resources/js/components/modals/HeroSlidesModal.tsx
@@ -283,7 +283,7 @@ export default function HeroSlidesModal({
                     </div>
                     {/* Botão de publicar movido para o footer para igualar ao modal de Destaques */}
                 </div>
-                <DialogFooter>
+                <DialogFooter className="flex-row justify-end gap-2">
                     <Button className="w-auto bg-black text-white hover:bg-black/80" variant="secondary" onClick={() => onOpenChange(false)}>
                         Fechar
                     </Button>


### PR DESCRIPTION
## Summary
- force the Hero Slides modal footer buttons into a right-aligned horizontal row to match the featured properties modal

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d4d06f3d14832c8f241f4c879005bb