### PR TITLE
Ajusta botoes do modal Hero Slides

### DIFF
--- a/resources/js/components/modals/HeroSlidesModal.tsx
+++ b/resources/js/components/modals/HeroSlidesModal.tsx
@@ -283,12 +283,13 @@ export default function HeroSlidesModal({
                     </div>
                     {/* Botão de publicar movido para o footer para igualar ao modal de Destaques */}
                 </div>
-                <DialogFooter className="flex-row justify-end gap-2">
+                <DialogFooter className="!flex-row !justify-end gap-2">
                     <Button className="w-auto bg-black text-white hover:bg-black/80" variant="secondary" onClick={() => onOpenChange(false)}>
                         Fechar
                     </Button>
                     <Button
-                        className="w-auto"
+                        className="w-auto bg-black text-white hover:bg-black/80"
+                        variant="secondary"
                         onClick={submit}
                         disabled={creating}
                         title={form.id ? "Atualizar destaque" : "Publicar destaque"}


### PR DESCRIPTION
## Summary
- garante que os botões Fechar e Publicar do modal de Hero Slides fiquem alinhados horizontalmente com o botão de publicação à direita
- aplica o mesmo estilo escuro ao botão de publicar para combinar com o botão de fechar

## Testing
- npm run lint *(falhou: problemas pré-existentes em arquivos não relacionados)*

------
https://chatgpt.com/codex/tasks/task_b_68d4d231e30c832c91ae770c086089a4