### PR TITLE
Fix hero slides modal footer button alignment

### DIFF
--- a/resources/js/components/modals/HeroSlidesModal.tsx
+++ b/resources/js/components/modals/HeroSlidesModal.tsx
@@ -283,21 +283,19 @@ export default function HeroSlidesModal({
                     </div>
                     {/* Botão de publicar movido para o footer para igualar ao modal de Destaques */}
                 </div>
-                <DialogFooter>
-                    <div className="flex w-full flex-row justify-end gap-2 sm:w-auto sm:flex-row">
-                        <Button className="w-auto bg-black text-white hover:bg-black/80" variant="secondary" onClick={() => onOpenChange(false)}>
-                            Fechar
-                        </Button>
-                        <Button
-                            className="w-auto bg-black text-white hover:bg-black/80"
-                            variant="secondary"
-                            onClick={submit}
-                            disabled={creating}
-                            title={form.id ? "Atualizar destaque" : "Publicar destaque"}
-                        >
-                            {form.id ? (creating ? "Atualizando." : "Atualizar") : (creating ? "Publicando." : "Publicar")}
-                        </Button>
-                    </div>
+                <DialogFooter className="flex-row justify-end gap-2">
+                    <Button className="w-auto bg-black text-white hover:bg-black/80" variant="secondary" onClick={() => onOpenChange(false)}>
+                        Fechar
+                    </Button>
+                    <Button
+                        className="w-auto bg-black text-white hover:bg-black/80"
+                        variant="secondary"
+                        onClick={submit}
+                        disabled={creating}
+                        title={form.id ? "Atualizar destaque" : "Publicar destaque"}
+                    >
+                        {form.id ? (creating ? "Atualizando." : "Atualizar") : (creating ? "Publicando." : "Publicar")}
+                    </Button>
                 </DialogFooter>
 
             </DialogContent>


### PR DESCRIPTION
## Summary
- ensure the Hero Slides modal footer forces a horizontal layout with right-aligned controls by overriding the default DialogFooter flex direction
- keep both "Fechar" and "Publicar" buttons grouped together at the bottom right of the modal for consistent placement

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d4d49ec10c832cb199d4d07ba9c9a2