### PR TITLE
Switch painel page to shared header

### DIFF
--- a/resources/js/main/components/ui/HeaderStandalone.jsx
+++ b/resources/js/main/components/ui/HeaderStandalone.jsx
@@ -33,7 +33,7 @@ export default function HeaderStandalone() {
         { name: 'Painel', path: '/painel', icon: 'Image', external: true },
     ];
 
-    const isActivePath = (path) => window.location?.pathname === path;
+    const isActivePath = (path) => (typeof window !== 'undefined' ? window.location?.pathname === path : false);
 
     const handleWhatsAppClick = () => {
         const message = encodeURIComponent('Olá! Gostaria de saber mais sobre os imóveis disponíveis.');

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -10,10 +10,10 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
-import AppLayout from '@/layouts/app-layout';
 import { Head } from '@inertiajs/react';
 import { apiFetch } from '@/lib/api';
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import HeaderStandalone from '@/main/components/ui/HeaderStandalone';
 // Removido CSS legado para manter aparência consistente com as demais views
 // import '../../css/oldsite.css';
 
@@ -21,15 +21,6 @@ import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import * as FeaturedActions from '@/actions/App/Http/Controllers/FeaturedPropertyController';
 import * as HeroActions from '@/actions/App/Http/Controllers/HeroSlideController';
 import * as ImageActions from '@/actions/App/Http/Controllers/ImageController';
-import { type BreadcrumbItem } from '@/types';
-import { painel } from '@/routes';
-
-const breadcrumbs: BreadcrumbItem[] = [
-    {
-        title: 'Painel',
-        href: painel().url,
-    },
-];
 
 type Image = {
     id: number;
@@ -348,15 +339,18 @@ export default function Painel() {
     };
 
     return (
-        <AppLayout breadcrumbs={breadcrumbs}>
+        <>
             <Head title="Painel" />
 
-            <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
-                {notice && (
-                    <Alert variant={notice.type === 'error' ? 'destructive' : 'default'}>
-                        <AlertTitle>{notice.title}</AlertTitle>
-                        {notice.message && <AlertDescription>{notice.message}</AlertDescription>}
-                    </Alert>
+            <div className="flex min-h-screen w-full flex-col bg-background">
+                <HeaderStandalone />
+
+                <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 pb-8 pt-24 sm:px-6 lg:px-8">
+                    {notice && (
+                        <Alert variant={notice.type === 'error' ? 'destructive' : 'default'}>
+                            <AlertTitle>{notice.title}</AlertTitle>
+                            {notice.message && <AlertDescription>{notice.message}</AlertDescription>}
+                        </Alert>
                 )}
                 {/* Hero Slides */}
                 <>
@@ -723,9 +717,9 @@ export default function Painel() {
                             editing={editingFeatured}
                         />
                 </>
-
-            </main>
-        </AppLayout>
+                </main>
+            </div>
+        </>
     );
 }
 


### PR DESCRIPTION
## Summary
- replace the painel page layout wrapper with the standalone site header so it shares the same navigation as other views
- update the standalone header helper to avoid referencing `window` during SSR rendering

## Testing
- npm run types *(fails: pre-existing TS2554 errors in resources/js/bootstrap/contact-bridge.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68d5f93bd1f8832c84035eb911ba9267