### PR TITLE
Align painel navbar styling with home view

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -95,6 +95,8 @@
     --warning-foreground: oklch(1 0 0);
     --error: oklch(0.65 0.23 29); /* ~red-500 */
     --error-foreground: oklch(1 0 0);
+    --color-text-primary: oklch(0.145 0 0);
+    --color-text-secondary: oklch(0.556 0 0);
 }
 
 .dark {
@@ -131,6 +133,8 @@
     --warning-foreground: oklch(1 0 0);
     --error: oklch(0.65 0.23 29);
     --error-foreground: oklch(1 0 0);
+    --color-text-primary: oklch(0.985 0 0);
+    --color-text-secondary: oklch(0.708 0 0);
 }
 
 @layer base {
@@ -140,5 +144,25 @@
 
     body {
         @apply bg-background text-foreground;
+    }
+}
+
+@layer components {
+    .container-responsive {
+        @apply container mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8;
+    }
+}
+
+@layer utilities {
+    .text-text-primary {
+        color: var(--color-text-primary);
+    }
+
+    .text-text-secondary {
+        color: var(--color-text-secondary);
+    }
+
+    .shadow-subtle {
+        box-shadow: 0 2px 12px rgba(15, 23, 42, 0.08);
     }
 }


### PR DESCRIPTION
## Summary
- define shared text color tokens for navbar text across themes
- add container-responsive, text color, and shadow utilities to match the home navbar styling in the painel view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d607614c74832cb44f2f026167e986