### PR TITLE
Ajusta a cor do botão de WhatsApp no painel

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -73,8 +73,8 @@
     --secondary-foreground: oklch(0.205 0 0);
     --muted: oklch(0.97 0 0);
     --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
+    --accent: oklch(0.761 0.201 149.74);
+    --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.577 0.245 27.325);
     --destructive-foreground: oklch(0.577 0.245 27.325);
     --border: oklch(0.922 0 0);
@@ -112,7 +112,7 @@
     --secondary-foreground: oklch(0.985 0 0);
     --muted: oklch(0.269 0 0);
     --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
+    --accent: oklch(0.761 0.201 149.74);
     --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.396 0.141 25.723);
     --destructive-foreground: oklch(0.637 0.237 25.331);


### PR DESCRIPTION
## Summary
- atualiza as variáveis CSS de cor de destaque para usar o mesmo verde do WhatsApp aplicado na landing page
- garante contraste adequado definindo o texto do botão de destaque como branco nos modos claro e escuro

## Testing
- não aplicável

------
https://chatgpt.com/codex/tasks/task_b_68d6091c18c4832cb8e7141a33befa55