### PR TITLE
Ajusta cor do preço exibido nos imóveis em destaque

### DIFF
--- a/resources/js/components/FeaturedCardInfo.tsx
+++ b/resources/js/components/FeaturedCardInfo.tsx
@@ -63,7 +63,7 @@ export default function FeaturedCardInfo({ title, neighborhood, bedrooms, bathro
             )}
 
             <div className="flex items-center justify-between">
-                <div className="text-2xl font-bold text-primary">{price || 'R$ 0,00'}</div>
+                <div className="text-2xl font-bold text-emerald-600">{price || 'R$ 0,00'}</div>
                 <Button className="w-auto bg-accent hover:bg-accent/90" variant="default">
                     <MessageCircle className="mr-2 h-4 w-4" /> Ver Detalhes
                 </Button>


### PR DESCRIPTION
## Summary
- altera o componente FeaturedCardInfo para aplicar a classe de texto verde ao preço exibido nos cards de imóveis em destaque

## Testing
- não foram executados testes (alteração apenas de estilo)


------
https://chatgpt.com/codex/tasks/task_b_68d60a5d8ca0832c81d4be4e3e8c2a92