### PR TITLE
feat: add progressive AppImage loader

### DIFF
--- a/main/src/components/AppImage.jsx
+++ b/main/src/components/AppImage.jsx
@@ -1,23 +1,117 @@
-import React from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
+import { cn } from "../utils/cn";
 
-function Image({
+const FALLBACK_SRC = "/assets/images/no_image.png";
+
+/**
+ * AppImage centralises progressive image loading for the marketing pages.
+ *
+ * ```jsx
+ * <AppImage
+ *   src="/hero/full-res.jpg"
+ *   placeholderSrc="/hero/placeholder.jpg"
+ *   srcSet="/hero/full-res.jpg 1920w, /hero/full-res@2x.jpg 2880w"
+ *   sizes="(min-width: 1024px) 100vw, 100vw"
+ *   fetchPriority="high"
+ *   loading="eager"
+ * />
+ * ```
+ *
+ * - `placeholderSrc` renders beneath the main image and fades out once the
+ *   full asset loads.
+ * - Pass `srcSet` and `sizes` to take advantage of responsive images without
+ *   duplicating logic in each consumer.
+ * - Non-critical images default to `loading="lazy"` and `decoding="async"`
+ *   to keep hero assets responsive while they stream in.
+ */
+const AppImage = forwardRef(function AppImage({
   src,
   alt = "Image Name",
   className = "",
+  wrapperClassName,
+  imgClassName,
+  placeholderSrc,
+  placeholderClassName = "",
+  onLoad: onLoadProp,
+  onError: onErrorProp,
+  srcSet,
+  sizes,
+  fetchPriority,
+  loading = "lazy",
+  decoding = "async",
   ...props
-}) {
+}, ref) {
+  const [currentSrc, setCurrentSrc] = useState(src);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [hasTriedFallback, setHasTriedFallback] = useState(false);
+
+  useEffect(() => {
+    setCurrentSrc(src);
+    setIsLoaded(false);
+    setHasTriedFallback(false);
+  }, [src]);
+
+  const handleLoad = (event) => {
+    setIsLoaded(true);
+    onLoadProp?.(event);
+  };
+
+  const handleError = (event) => {
+    if (!hasTriedFallback && currentSrc !== FALLBACK_SRC) {
+      setHasTriedFallback(true);
+      setCurrentSrc(FALLBACK_SRC);
+      setIsLoaded(false);
+    }
+
+    onErrorProp?.(event);
+  };
+
+  const resolvedWrapperClassName = cn(
+    "relative block overflow-hidden",
+    wrapperClassName ?? className
+  );
+
+  const resolvedImgClassName = cn(
+    "h-full w-full object-cover transition-all duration-500",
+    imgClassName ?? className,
+    isLoaded ? "opacity-100 scale-100" : "opacity-0 scale-105"
+  );
+
+  const resolvedPlaceholderClassName = cn(
+    "absolute inset-0 z-[1] h-full w-full object-cover blur-sm transition-opacity duration-500",
+    isLoaded ? "opacity-0" : "opacity-100",
+    placeholderClassName
+  );
 
   return (
-    <img
-      src={src}
-      alt={alt}
-      className={className}
-      onError={(e) => {
-        e.target.src = "/assets/images/no_image.png"
-      }}
-      {...props}
-    />
-  );
-}
+    <span className={resolvedWrapperClassName}>
+      {placeholderSrc && (
+        <img
+          src={placeholderSrc}
+          alt=""
+          aria-hidden="true"
+          className={resolvedPlaceholderClassName}
+          loading="lazy"
+          decoding="async"
+        />
+      )}
 
-export default Image;
+      <img
+        ref={ref}
+        src={currentSrc}
+        alt={alt}
+        className={cn("relative z-[2]", resolvedImgClassName)}
+        onLoad={handleLoad}
+        onError={handleError}
+        srcSet={srcSet}
+        sizes={sizes}
+        fetchPriority={fetchPriority}
+        loading={loading}
+        decoding={decoding}
+        {...props}
+      />
+    </span>
+  );
+});
+
+export default AppImage;

--- a/main/src/pages/about-brand-story-credentials/components/ClientSuccessSection.jsx
+++ b/main/src/pages/about-brand-story-credentials/components/ClientSuccessSection.jsx
@@ -2,6 +2,29 @@ import React, { useState } from 'react';
 import Icon from '../../../components/AppIcon';
 import Image from '../../../components/AppImage';
 
+const buildPlaceholderSrc = (url) => {
+  if (!url) return null;
+
+  try {
+    const [path, search = ""] = url.split('?');
+    const params = new URLSearchParams(search);
+
+    params.set('q', '30');
+
+    if (!params.has('auto')) {
+      params.set('auto', 'format');
+    }
+
+    if (!params.has('blur')) {
+      params.set('blur', '20');
+    }
+
+    return `${path}?${params.toString()}`;
+  } catch (error) {
+    return url;
+  }
+};
+
 const ClientSuccessSection = () => {
   const [activeStory, setActiveStory] = useState(0);
 
@@ -133,7 +156,9 @@ const ClientSuccessSection = () => {
                     <Image
                       src={successStories?.[activeStory]?.clientImage}
                       alt={successStories?.[activeStory]?.clientName}
-                      className="w-full h-full object-cover"
+                      wrapperClassName="w-full h-full"
+                      imgClassName="w-full h-full object-cover"
+                      placeholderSrc={buildPlaceholderSrc(successStories?.[activeStory]?.clientImage)}
                     />
                   </div>
                   <h3 className="text-xl font-semibold text-text-primary mb-2">
@@ -217,7 +242,9 @@ const ClientSuccessSection = () => {
                     <Image
                       src={testimonial?.image}
                       alt={testimonial?.name}
-                      className="w-full h-full object-cover"
+                      wrapperClassName="w-full h-full"
+                      imgClassName="w-full h-full object-cover"
+                      placeholderSrc={buildPlaceholderSrc(testimonial?.image)}
                     />
                   </div>
                   <div className="flex-1">

--- a/main/src/pages/about-brand-story-credentials/components/HeroSection.jsx
+++ b/main/src/pages/about-brand-story-credentials/components/HeroSection.jsx
@@ -2,6 +2,29 @@ import React from 'react';
 import Image from '../../../components/AppImage';
 import Button from '../../../components/ui/Button';
 
+const buildPlaceholderSrc = (url) => {
+  if (!url) return null;
+
+  try {
+    const [path, search = ""] = url.split('?');
+    const params = new URLSearchParams(search);
+
+    params.set('q', '30');
+
+    if (!params.has('auto')) {
+      params.set('auto', 'format');
+    }
+
+    if (!params.has('blur')) {
+      params.set('blur', '35');
+    }
+
+    return `${path}?${params.toString()}`;
+  } catch (error) {
+    return url;
+  }
+};
+
 const HeroSection = () => {
   const handleWhatsAppClick = () => {
     const message = encodeURIComponent('Olá! Vi o perfil da Casa Conecta e gostaria de conhecer mais sobre os serviços de consultoria imobiliária.');
@@ -73,7 +96,11 @@ const HeroSection = () => {
               <Image
                 src="https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=600&h=400&fit=crop"
                 alt="Equipe Casa Conecta em frente ao Flamboyant Shopping"
-                className="w-full h-96 object-cover"
+                wrapperClassName="w-full h-96"
+                imgClassName="w-full h-full object-cover"
+                placeholderSrc={buildPlaceholderSrc('https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=600&h=400&fit=crop')}
+                loading="eager"
+                fetchPriority="high"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent"></div>
             </div>

--- a/main/src/pages/homepage-premium-real-estate-consultancy/components/FeaturedProperties.jsx
+++ b/main/src/pages/homepage-premium-real-estate-consultancy/components/FeaturedProperties.jsx
@@ -3,6 +3,29 @@ import Icon from '../../../components/AppIcon';
 import Image from '../../../components/AppImage';
 import Button from '../../../components/ui/Button';
 
+const buildPlaceholderSrc = (url) => {
+  if (!url) return null;
+
+  try {
+    const [path, search = ""] = url.split('?');
+    const params = new URLSearchParams(search);
+
+    params.set('q', '30');
+
+    if (!params.has('auto')) {
+      params.set('auto', 'format');
+    }
+
+    if (!params.has('blur')) {
+      params.set('blur', '35');
+    }
+
+    return `${path}?${params.toString()}`;
+  } catch (error) {
+    return url;
+  }
+};
+
 const FeaturedProperties = () => {
   const [showMore, setShowMore] = useState(false);
   const [favorites, setFavorites] = useState(new Set());
@@ -369,7 +392,9 @@ const FeaturedProperties = () => {
                       <Image
                         src={property?.image}
                         alt={property?.title}
-                        className="w-full h-full object-cover transition-transform duration-300 hover:scale-105"
+                        wrapperClassName="w-full h-64"
+                        imgClassName="w-full h-full object-cover transition-transform duration-300 hover:scale-105"
+                        placeholderSrc={buildPlaceholderSrc(property?.image)}
                       />
                     </div>
                     

--- a/main/src/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
+++ b/main/src/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
@@ -3,6 +3,29 @@ import Icon from '../../../components/AppIcon';
 import Image from '../../../components/AppImage';
 import Button from '../../../components/ui/Button';
 
+const buildPlaceholderSrc = (url) => {
+  if (!url) return null;
+
+  try {
+    const [path, search = ""] = url.split('?');
+    const params = new URLSearchParams(search);
+
+    params.set('q', '30');
+
+    if (!params.has('auto')) {
+      params.set('auto', 'format');
+    }
+
+    if (!params.has('blur')) {
+      params.set('blur', '40');
+    }
+
+    return `${path}?${params.toString()}`;
+  } catch (error) {
+    return url;
+  }
+};
+
 const HeroCarousel = () => {
   const [currentSlide, setCurrentSlide] = useState(0);
 
@@ -88,7 +111,10 @@ const HeroCarousel = () => {
               <Image
                 src={property?.image}
                 alt={property?.title}
-                className="w-full h-full object-cover object-center"
+                wrapperClassName="w-full h-full"
+                imgClassName="w-full h-full object-cover object-center"
+                placeholderSrc={buildPlaceholderSrc(property?.image)}
+                fetchPriority={index === currentSlide ? 'high' : undefined}
                 loading={index === 0 ? 'eager' : 'lazy'}
               />
               <div className="absolute inset-0 hero-overlay" />

--- a/resources/js/main/components/AppImage.jsx
+++ b/resources/js/main/components/AppImage.jsx
@@ -1,23 +1,117 @@
-import React from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
+import { cn } from "../utils/cn";
 
-function Image({
+const FALLBACK_SRC = "/assets/images/no_image.png";
+
+/**
+ * AppImage centralises progressive image loading for the marketing pages.
+ *
+ * ```jsx
+ * <AppImage
+ *   src="/hero/full-res.jpg"
+ *   placeholderSrc="/hero/placeholder.jpg"
+ *   srcSet="/hero/full-res.jpg 1920w, /hero/full-res@2x.jpg 2880w"
+ *   sizes="(min-width: 1024px) 100vw, 100vw"
+ *   fetchPriority="high"
+ *   loading="eager"
+ * />
+ * ```
+ *
+ * - `placeholderSrc` renders beneath the main image and fades out once the
+ *   full asset loads.
+ * - Pass `srcSet` and `sizes` to take advantage of responsive images without
+ *   duplicating logic in each consumer.
+ * - Non-critical images default to `loading="lazy"` and `decoding="async"`
+ *   to keep hero assets responsive while they stream in.
+ */
+const AppImage = forwardRef(function AppImage({
   src,
   alt = "Image Name",
   className = "",
+  wrapperClassName,
+  imgClassName,
+  placeholderSrc,
+  placeholderClassName = "",
+  onLoad: onLoadProp,
+  onError: onErrorProp,
+  srcSet,
+  sizes,
+  fetchPriority,
+  loading = "lazy",
+  decoding = "async",
   ...props
-}) {
+}, ref) {
+  const [currentSrc, setCurrentSrc] = useState(src);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [hasTriedFallback, setHasTriedFallback] = useState(false);
+
+  useEffect(() => {
+    setCurrentSrc(src);
+    setIsLoaded(false);
+    setHasTriedFallback(false);
+  }, [src]);
+
+  const handleLoad = (event) => {
+    setIsLoaded(true);
+    onLoadProp?.(event);
+  };
+
+  const handleError = (event) => {
+    if (!hasTriedFallback && currentSrc !== FALLBACK_SRC) {
+      setHasTriedFallback(true);
+      setCurrentSrc(FALLBACK_SRC);
+      setIsLoaded(false);
+    }
+
+    onErrorProp?.(event);
+  };
+
+  const resolvedWrapperClassName = cn(
+    "relative block overflow-hidden",
+    wrapperClassName ?? className
+  );
+
+  const resolvedImgClassName = cn(
+    "h-full w-full object-cover transition-all duration-500",
+    imgClassName ?? className,
+    isLoaded ? "opacity-100 scale-100" : "opacity-0 scale-105"
+  );
+
+  const resolvedPlaceholderClassName = cn(
+    "absolute inset-0 z-[1] h-full w-full object-cover blur-sm transition-opacity duration-500",
+    isLoaded ? "opacity-0" : "opacity-100",
+    placeholderClassName
+  );
 
   return (
-    <img
-      src={src}
-      alt={alt}
-      className={className}
-      onError={(e) => {
-        e.target.src = "/assets/images/no_image.png"
-      }}
-      {...props}
-    />
-  );
-}
+    <span className={resolvedWrapperClassName}>
+      {placeholderSrc && (
+        <img
+          src={placeholderSrc}
+          alt=""
+          aria-hidden="true"
+          className={resolvedPlaceholderClassName}
+          loading="lazy"
+          decoding="async"
+        />
+      )}
 
-export default Image;
+      <img
+        ref={ref}
+        src={currentSrc}
+        alt={alt}
+        className={cn("relative z-[2]", resolvedImgClassName)}
+        onLoad={handleLoad}
+        onError={handleError}
+        srcSet={srcSet}
+        sizes={sizes}
+        fetchPriority={fetchPriority}
+        loading={loading}
+        decoding={decoding}
+        {...props}
+      />
+    </span>
+  );
+});
+
+export default AppImage;

--- a/resources/js/main/pages/about-brand-story-credentials/components/ClientSuccessSection.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/components/ClientSuccessSection.jsx
@@ -2,6 +2,29 @@ import React, { useState } from 'react';
 import Icon from '../../../components/AppIcon';
 import Image from '../../../components/AppImage';
 
+const buildPlaceholderSrc = (url) => {
+  if (!url) return null;
+
+  try {
+    const [path, search = ""] = url.split('?');
+    const params = new URLSearchParams(search);
+
+    params.set('q', '30');
+
+    if (!params.has('auto')) {
+      params.set('auto', 'format');
+    }
+
+    if (!params.has('blur')) {
+      params.set('blur', '20');
+    }
+
+    return `${path}?${params.toString()}`;
+  } catch (error) {
+    return url;
+  }
+};
+
 const ClientSuccessSection = () => {
   const [activeStory, setActiveStory] = useState(0);
 
@@ -133,7 +156,9 @@ const ClientSuccessSection = () => {
                     <Image
                       src={successStories?.[activeStory]?.clientImage}
                       alt={successStories?.[activeStory]?.clientName}
-                      className="w-full h-full object-cover"
+                      wrapperClassName="w-full h-full"
+                      imgClassName="w-full h-full object-cover"
+                      placeholderSrc={buildPlaceholderSrc(successStories?.[activeStory]?.clientImage)}
                     />
                   </div>
                   <h3 className="text-xl font-semibold text-text-primary mb-2">
@@ -217,7 +242,9 @@ const ClientSuccessSection = () => {
                     <Image
                       src={testimonial?.image}
                       alt={testimonial?.name}
-                      className="w-full h-full object-cover"
+                      wrapperClassName="w-full h-full"
+                      imgClassName="w-full h-full object-cover"
+                      placeholderSrc={buildPlaceholderSrc(testimonial?.image)}
                     />
                   </div>
                   <div className="flex-1">

--- a/resources/js/main/pages/about-brand-story-credentials/components/HeroSection.jsx
+++ b/resources/js/main/pages/about-brand-story-credentials/components/HeroSection.jsx
@@ -3,6 +3,29 @@ import Image from '../../../components/AppImage';
 import Button from '../../../components/ui/Button';
 import { openWhatsApp, openPhone, formatPhoneDisplay, useContactInfo } from '@/lib/contact';
 
+const buildPlaceholderSrc = (url) => {
+  if (!url) return null;
+
+  try {
+    const [path, search = ""] = url.split('?');
+    const params = new URLSearchParams(search);
+
+    params.set('q', '30');
+
+    if (!params.has('auto')) {
+      params.set('auto', 'format');
+    }
+
+    if (!params.has('blur')) {
+      params.set('blur', '35');
+    }
+
+    return `${path}?${params.toString()}`;
+  } catch (error) {
+    return url;
+  }
+};
+
 const HeroSection = () => {
   const contact = useContactInfo();
   const handleWhatsAppClick = () => {
@@ -73,7 +96,11 @@ const HeroSection = () => {
               <Image
                 src="https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=600&h=400&fit=crop"
                 alt="Equipe Casa Conecta em frente ao Flamboyant Shopping"
-                className="w-full h-96 object-cover"
+                wrapperClassName="w-full h-96"
+                imgClassName="w-full h-full object-cover"
+                placeholderSrc={buildPlaceholderSrc('https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=600&h=400&fit=crop')}
+                loading="eager"
+                fetchPriority="high"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent"></div>
             </div>

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/FeaturedProperties.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/FeaturedProperties.jsx
@@ -3,6 +3,29 @@ import Icon from '../../../components/AppIcon';
 import Image from '../../../components/AppImage';
 import Button from '../../../components/ui/Button';
 
+const buildPlaceholderSrc = (url) => {
+  if (!url) return null;
+
+  try {
+    const [path, search = ""] = url.split('?');
+    const params = new URLSearchParams(search);
+
+    params.set('q', '30');
+
+    if (!params.has('auto')) {
+      params.set('auto', 'format');
+    }
+
+    if (!params.has('blur')) {
+      params.set('blur', '35');
+    }
+
+    return `${path}?${params.toString()}`;
+  } catch (error) {
+    return url;
+  }
+};
+
 const normalizeImageValue = (value) => {
   if (!value) return null;
   if (typeof value === 'string') return value;
@@ -585,7 +608,9 @@ const FeaturedProperties = () => {
                         <Image
                           src={primaryImage}
                           alt={property?.title}
-                          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                          wrapperClassName="h-64 w-full"
+                          imgClassName="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                          placeholderSrc={buildPlaceholderSrc(primaryImage)}
                           loading="lazy"
                         />
                         <span className="pointer-events-none absolute bottom-4 right-4 flex items-center gap-1 rounded-full bg-black/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">
@@ -701,7 +726,9 @@ const FeaturedProperties = () => {
                 <Image
                   src={activeGallery[activeImageIndex]}
                   alt={`${activeProperty.title} - imagem ${activeImageIndex + 1}`}
-                  className="h-[60vh] w-full object-cover"
+                  wrapperClassName="block w-full"
+                  imgClassName="h-[60vh] w-full object-cover"
+                  placeholderSrc={buildPlaceholderSrc(activeGallery[activeImageIndex])}
                 />
 
                 {hasGalleryNavigation && (
@@ -741,7 +768,9 @@ const FeaturedProperties = () => {
                       <Image
                         src={thumb}
                         alt={`${activeProperty.title} - miniatura ${index + 1}`}
-                        className="h-full w-full object-cover"
+                        wrapperClassName="h-full w-full"
+                        imgClassName="h-full w-full object-cover"
+                        placeholderSrc={buildPlaceholderSrc(thumb)}
                         loading="lazy"
                       />
                       {index === activeImageIndex && (

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
@@ -3,6 +3,29 @@ import Icon from '../../../components/AppIcon';
 import Image from '../../../components/AppImage';
 import Button from '../../../components/ui/Button';
 
+const buildPlaceholderSrc = (url) => {
+  if (!url) return null;
+
+  try {
+    const [path, search = ""] = url.split('?');
+    const params = new URLSearchParams(search);
+
+    params.set('q', '30');
+
+    if (!params.has('auto')) {
+      params.set('auto', 'format');
+    }
+
+    if (!params.has('blur')) {
+      params.set('blur', '40');
+    }
+
+    return `${path}?${params.toString()}`;
+  } catch (error) {
+    return url;
+  }
+};
+
 const HeroCarousel = () => {
   const [currentSlide, setCurrentSlide] = useState(0);
   const [heroProperties, setHeroProperties] = useState([]);
@@ -113,7 +136,10 @@ const HeroCarousel = () => {
               <Image
                 src={property?.image}
                 alt={property?.title}
-                className="w-full h-full object-cover object-center"
+                wrapperClassName="w-full h-full"
+                imgClassName="w-full h-full object-cover object-center"
+                placeholderSrc={buildPlaceholderSrc(property?.image)}
+                fetchPriority={index === currentSlide ? 'high' : undefined}
                 loading={index === 0 ? 'eager' : 'lazy'}
               />
               <div className="absolute inset-0 hero-overlay" />


### PR DESCRIPTION
## Summary
- convert the shared AppImage component into a progressive image helper with placeholder support, lazy defaults, and gated fallbacks
- update hero carousel, featured listings, and brand pages to pass responsive image props and placeholder URLs for smoother loading
- mirror the progressive image API updates in the duplicated main/src marketing pages to keep parity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d6916d33e0832c9e2c50f560876a43