### PR TITLE
Add consent-aware image caching for marketing images

### DIFF
--- a/resources/js/lib/imageCache.ts
+++ b/resources/js/lib/imageCache.ts
@@ -1,0 +1,392 @@
+const CACHE_NAME = "app-image-cache-v1";
+const IDB_NAME = "app-image-cache";
+const IDB_STORE_NAME = "images";
+const META_PREFIX = "image-cache-meta:";
+const DEFAULT_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+export type ImageCacheConsent = "granted" | "denied" | "unknown";
+export const IMAGE_CACHE_CONSENT_KEY = "image-cache-consent";
+export const IMAGE_CACHE_CONSENT_EVENT = "image-cache-consent-change";
+
+const CONSENT_COOKIE_TTL_DAYS = 365; // 1 year
+
+export type ImageCacheMetadata = {
+  expiresAt: number;
+};
+
+/**
+ * DevTools verification checklist for future maintainers:
+ * 1. Open the "Application" tab and watch the Cache Storage + IndexedDB entries.
+ * 2. Accept the banner to grant consent, reload a hero/gallery page, then
+ *    revisit it to confirm responses are served from cache (status `(disk cache)`
+ *    or fetched blob URLs).
+ * 3. Decline consent and reload to ensure cached entries disappear and network
+ *    fetches resume.
+ */
+
+function supportsWindow(): boolean {
+  return typeof window !== "undefined";
+}
+
+function supportsCacheStorage(): boolean {
+  return supportsWindow() && typeof caches !== "undefined";
+}
+
+function supportsIndexedDB(): boolean {
+  return supportsWindow() && typeof indexedDB !== "undefined";
+}
+
+function getMetaKey(url: string): string {
+  return `${META_PREFIX}${encodeURIComponent(url)}`;
+}
+
+function persistMetadata(url: string, ttlSeconds: number): void {
+  if (!supportsWindow()) return;
+  try {
+    const expiresAt = Date.now() + ttlSeconds * 1000;
+    const entry: ImageCacheMetadata = { expiresAt };
+    window.localStorage?.setItem(getMetaKey(url), JSON.stringify(entry));
+    const expireDate = new Date(expiresAt);
+    document.cookie = `${encodeURIComponent(getMetaKey(url))}=1; path=/; expires=${expireDate.toUTCString()}`;
+  } catch {
+    // Swallow storage errors: cache will behave as non-persistent.
+  }
+}
+
+function readMetadata(url: string): ImageCacheMetadata | null {
+  if (!supportsWindow()) return null;
+  try {
+    const raw = window.localStorage?.getItem(getMetaKey(url));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as ImageCacheMetadata | null;
+    if (!parsed || typeof parsed.expiresAt !== "number") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function removeMetadata(url: string): void {
+  if (!supportsWindow()) return;
+  try {
+    const key = getMetaKey(url);
+    window.localStorage?.removeItem(key);
+    document.cookie = `${encodeURIComponent(key)}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  } catch {
+    // Ignore failures
+  }
+}
+
+function getCookieValue(name: string): string | null {
+  if (!supportsWindow()) return null;
+  const decoded = decodeURIComponent(name);
+  const cookies = document.cookie?.split(";") ?? [];
+  for (const cookie of cookies) {
+    const [rawKey, rawValue] = cookie.trim().split("=");
+    if (rawKey === decoded) {
+      return rawValue ?? "";
+    }
+  }
+  return null;
+}
+
+function persistConsent(value: ImageCacheConsent): void {
+  if (!supportsWindow()) return;
+  try {
+    window.localStorage?.setItem(IMAGE_CACHE_CONSENT_KEY, value);
+  } catch {
+    // Ignore storage errors
+  }
+
+  try {
+    const expires = new Date(Date.now() + CONSENT_COOKIE_TTL_DAYS * 24 * 60 * 60 * 1000);
+    document.cookie = `${encodeURIComponent(IMAGE_CACHE_CONSENT_KEY)}=${encodeURIComponent(value)}; path=/; expires=${expires.toUTCString()}`;
+  } catch {
+    // Ignore cookie errors
+  }
+}
+
+function dispatchConsentEvent(value: ImageCacheConsent): void {
+  if (!supportsWindow()) return;
+  try {
+    window.dispatchEvent(new CustomEvent(IMAGE_CACHE_CONSENT_EVENT, { detail: { consent: value } }));
+  } catch {
+    // Older browsers without CustomEvent support can silently fail.
+  }
+}
+
+function openImageDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (!supportsIndexedDB()) {
+      reject(new Error("IndexedDB not supported"));
+      return;
+    }
+
+    const request = indexedDB.open(IDB_NAME, 1);
+    request.onerror = () => reject(request.error ?? new Error("Failed to open IndexedDB"));
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(IDB_STORE_NAME)) {
+        db.createObjectStore(IDB_STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+async function storeBlobInIndexedDB(url: string, blob: Blob): Promise<void> {
+  const db = await openImageDb();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(IDB_STORE_NAME, "readwrite");
+    const store = transaction.objectStore(IDB_STORE_NAME);
+    const request = store.put(blob, url);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error ?? new Error("Failed to store blob"));
+    transaction.oncomplete = () => db.close();
+    transaction.onerror = () => db.close();
+  });
+}
+
+async function readBlobFromIndexedDB(url: string): Promise<Blob | null> {
+  const db = await openImageDb();
+  return new Promise<Blob | null>((resolve, reject) => {
+    const transaction = db.transaction(IDB_STORE_NAME, "readonly");
+    const store = transaction.objectStore(IDB_STORE_NAME);
+    const request = store.get(url);
+    request.onsuccess = () => {
+      const result = request.result ?? null;
+      resolve(result ?? null);
+    };
+    request.onerror = () => reject(request.error ?? new Error("Failed to read blob"));
+    transaction.oncomplete = () => db.close();
+    transaction.onerror = () => db.close();
+  });
+}
+
+async function deleteBlobFromIndexedDB(url: string): Promise<void> {
+  const db = await openImageDb();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(IDB_STORE_NAME, "readwrite");
+    const store = transaction.objectStore(IDB_STORE_NAME);
+    const request = store.delete(url);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error ?? new Error("Failed to delete blob"));
+    transaction.oncomplete = () => db.close();
+    transaction.onerror = () => db.close();
+  });
+}
+
+async function readBlobFromCacheStorage(url: string): Promise<Blob | null> {
+  if (!supportsCacheStorage()) return null;
+  const cache = await caches.open(CACHE_NAME);
+  const response = await cache.match(url);
+  if (!response) return null;
+  return response.blob();
+}
+
+async function storeBlobInCacheStorage(url: string, blob: Blob): Promise<void> {
+  if (!supportsCacheStorage()) return;
+  const cache = await caches.open(CACHE_NAME);
+  const headers = new Headers();
+  if (blob.type) {
+    headers.set("Content-Type", blob.type);
+  }
+  const response = new Response(blob, { headers });
+  await cache.put(url, response);
+}
+
+async function deleteBlobFromCacheStorage(url: string): Promise<void> {
+  if (!supportsCacheStorage()) return;
+  const cache = await caches.open(CACHE_NAME);
+  await cache.delete(url);
+}
+
+async function storeBlob(url: string, blob: Blob, ttlSeconds: number): Promise<boolean> {
+  try {
+    if (supportsCacheStorage()) {
+      await storeBlobInCacheStorage(url, blob);
+      persistMetadata(url, ttlSeconds);
+      return true;
+    }
+    if (supportsIndexedDB()) {
+      await storeBlobInIndexedDB(url, blob);
+      persistMetadata(url, ttlSeconds);
+      return true;
+    }
+  } catch {
+    // Fall through
+  }
+  return false;
+}
+
+async function readBlob(url: string): Promise<Blob | null> {
+  try {
+    if (supportsCacheStorage()) {
+      const response = await readBlobFromCacheStorage(url);
+      if (response) return response;
+    }
+    if (supportsIndexedDB()) {
+      return await readBlobFromIndexedDB(url);
+    }
+  } catch {
+    // Fall through to null
+  }
+  return null;
+}
+
+async function deleteBlob(url: string): Promise<void> {
+  try {
+    if (supportsCacheStorage()) {
+      await deleteBlobFromCacheStorage(url);
+    }
+    if (supportsIndexedDB()) {
+      await deleteBlobFromIndexedDB(url);
+    }
+  } catch {
+    // Ignore failures
+  }
+}
+
+export function getImageCacheConsent(): ImageCacheConsent {
+  if (!supportsWindow()) return "unknown";
+  try {
+    const stored = window.localStorage?.getItem(IMAGE_CACHE_CONSENT_KEY);
+    if (stored === "granted" || stored === "denied") {
+      return stored;
+    }
+  } catch {
+    // Ignore storage issues
+  }
+
+  const cookie = getCookieValue(IMAGE_CACHE_CONSENT_KEY);
+  if (cookie === "granted" || cookie === "denied") {
+    return cookie;
+  }
+
+  return "unknown";
+}
+
+export function hasImageCacheConsent(): boolean {
+  return getImageCacheConsent() === "granted";
+}
+
+export function setImageCacheConsent(consent: ImageCacheConsent): void {
+  if (consent === "unknown") {
+    removeConsent();
+    dispatchConsentEvent("unknown");
+    return;
+  }
+
+  persistConsent(consent);
+  dispatchConsentEvent(consent);
+}
+
+function removeConsent(): void {
+  if (!supportsWindow()) return;
+  try {
+    window.localStorage?.removeItem(IMAGE_CACHE_CONSENT_KEY);
+    document.cookie = `${encodeURIComponent(IMAGE_CACHE_CONSENT_KEY)}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  } catch {
+    // Ignore failures
+  }
+}
+
+export async function getCachedImageUrl(url: string): Promise<string | null> {
+  if (!supportsWindow() || !url) return null;
+  const meta = readMetadata(url);
+  if (!meta) return null;
+  if (Date.now() > meta.expiresAt) {
+    await removeImageCacheEntry(url);
+    return null;
+  }
+
+  const blob = await readBlob(url);
+  if (!blob || blob.size === 0) {
+    await removeImageCacheEntry(url);
+    return null;
+  }
+
+  if (typeof URL === "undefined" || typeof URL.createObjectURL !== "function") {
+    return null;
+  }
+
+  return URL.createObjectURL(blob);
+}
+
+export async function fetchAndCacheImage(url: string, ttlSeconds: number = DEFAULT_TTL_SECONDS): Promise<string> {
+  if (!supportsWindow() || !url) {
+    throw new Error("Image caching is only available in the browser");
+  }
+
+  if (!hasImageCacheConsent()) {
+    throw new Error("Consent required for image caching");
+  }
+
+  const response = await fetch(url, { credentials: "same-origin" });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch image: ${response.status}`);
+  }
+
+  const blob = await response.clone().blob();
+  if (!blob || blob.size === 0) {
+    throw new Error("Received empty image payload");
+  }
+
+  await storeBlob(url, blob, ttlSeconds);
+
+  if (typeof URL === "undefined" || typeof URL.createObjectURL !== "function") {
+    throw new Error("Object URLs are not supported in this environment");
+  }
+
+  return URL.createObjectURL(blob);
+}
+
+export async function removeImageCacheEntry(url: string): Promise<void> {
+  if (!supportsWindow() || !url) return;
+  await deleteBlob(url);
+  removeMetadata(url);
+}
+
+export async function clearImageCache(): Promise<void> {
+  if (!supportsWindow()) return;
+
+  if (supportsCacheStorage()) {
+    try {
+      const names = await caches.keys();
+      await Promise.all(names.filter((name) => name === CACHE_NAME).map((name) => caches.delete(name)));
+    } catch {
+      // Ignore failures
+    }
+  }
+
+  if (supportsIndexedDB()) {
+    try {
+      await new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase(IDB_NAME);
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+      });
+    } catch {
+      // Ignore failures
+    }
+  }
+
+  try {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < (window.localStorage?.length ?? 0); i += 1) {
+      const key = window.localStorage?.key(i) ?? "";
+      if (key.startsWith(META_PREFIX)) {
+        keysToRemove.push(key);
+      }
+    }
+    keysToRemove.forEach((key) => {
+      window.localStorage?.removeItem(key);
+      document.cookie = `${encodeURIComponent(key)}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    });
+  } catch {
+    // Ignore storage failures
+  }
+}
+
+export { DEFAULT_TTL_SECONDS as IMAGE_CACHE_DEFAULT_TTL };

--- a/resources/js/main/Routes.jsx
+++ b/resources/js/main/Routes.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { BrowserRouter, Routes as RouterRoutes, Route } from "react-router-dom";
-import ScrollToTop from "@/main/components/ScrollToTop";
 import ErrorBoundary from "@/main/components/ErrorBoundary";
+import ScrollToTop from "@/main/components/ScrollToTop";
+import CookieConsentBanner from "@/main/components/CookieConsentBanner";
 import NotFound from "@/main/pages/NotFound";
 import FAQPage from './pages/faq-comprehensive-buyer-education';
 import AboutBrandStoryCredentials from './pages/about-brand-story-credentials';
@@ -20,6 +21,7 @@ const Routes = () => {
     <BrowserRouter>
       <ErrorBoundary>
         <ScrollToTop />
+        <CookieConsentBanner />
         <AnalyticsWrapper>
           <RouterRoutes>
             {/* Define your route here */}

--- a/resources/js/main/components/AppImage.jsx
+++ b/resources/js/main/components/AppImage.jsx
@@ -1,5 +1,12 @@
-import React, { forwardRef, useEffect, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from "../utils/cn";
+import {
+  fetchAndCacheImage,
+  getCachedImageUrl,
+  hasImageCacheConsent,
+  IMAGE_CACHE_CONSENT_EVENT,
+  removeImageCacheEntry,
+} from "@/lib/imageCache";
 
 const FALLBACK_SRC = "/assets/images/no_image.png";
 
@@ -23,6 +30,12 @@ const FALLBACK_SRC = "/assets/images/no_image.png";
  *   duplicating logic in each consumer.
  * - Non-critical images default to `loading="lazy"` and `decoding="async"`
  *   to keep hero assets responsive while they stream in.
+ *
+ * Historically this component only orchestrated placeholders/responsive
+ * sources, forcing every visit to re-download heavy hero/gallery assets. The
+ * implementation now integrates with `imageCache` so that, once visitors grant
+ * consent for cookie/localStorage usage, high-resolution payloads are persisted
+ * and reused across sessions without disrupting the fade-in placeholder flow.
  */
 const AppImage = forwardRef(function AppImage({
   src,
@@ -41,15 +54,105 @@ const AppImage = forwardRef(function AppImage({
   decoding = "async",
   ...props
 }, ref) {
-  const [currentSrc, setCurrentSrc] = useState(src);
+  const [currentSrc, setCurrentSrc] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const [hasTriedFallback, setHasTriedFallback] = useState(false);
+  const [hasConsent, setHasConsent] = useState(() => hasImageCacheConsent());
+  const objectUrlRef = useRef(null);
+
+  const updateObjectUrl = useCallback((nextUrl) => {
+    if (typeof window === "undefined") return;
+    if (typeof URL === "undefined" || typeof URL.revokeObjectURL !== "function") {
+      objectUrlRef.current = nextUrl ?? null;
+      return;
+    }
+    const currentUrl = objectUrlRef.current;
+    if (currentUrl && currentUrl !== nextUrl) {
+      URL.revokeObjectURL(currentUrl);
+    }
+    objectUrlRef.current = nextUrl ?? null;
+  }, []);
 
   useEffect(() => {
-    setCurrentSrc(src);
+    if (typeof window === "undefined") return undefined;
+
+    const handleConsentChange = (event) => {
+      const consent = event?.detail?.consent;
+      setHasConsent(consent === "granted");
+    };
+
+    window.addEventListener(IMAGE_CACHE_CONSENT_EVENT, handleConsentChange);
+
+    return () => {
+      window.removeEventListener(IMAGE_CACHE_CONSENT_EVENT, handleConsentChange);
+    };
+  }, []);
+
+  useEffect(() => () => updateObjectUrl(null), [updateObjectUrl]);
+
+  useEffect(() => {
     setIsLoaded(false);
     setHasTriedFallback(false);
   }, [src]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    updateObjectUrl(null);
+    setCurrentSrc(undefined);
+
+    if (!src) {
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    if (typeof window === "undefined" || !hasConsent) {
+      setCurrentSrc(src);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    (async () => {
+      try {
+        const cachedUrl = await getCachedImageUrl(src);
+        if (!isMounted) {
+          if (cachedUrl) {
+            updateObjectUrl(null);
+            if (typeof URL !== "undefined" && typeof URL.revokeObjectURL === "function") {
+              URL.revokeObjectURL(cachedUrl);
+            }
+          }
+          return;
+        }
+
+        if (cachedUrl) {
+          updateObjectUrl(cachedUrl);
+          setCurrentSrc(cachedUrl);
+          return;
+        }
+
+        const objectUrl = await fetchAndCacheImage(src);
+        if (!isMounted) {
+          if (typeof URL !== "undefined" && typeof URL.revokeObjectURL === "function") {
+            URL.revokeObjectURL(objectUrl);
+          }
+          return;
+        }
+
+        updateObjectUrl(objectUrl);
+        setCurrentSrc(objectUrl);
+      } catch (error) {
+        updateObjectUrl(null);
+        setCurrentSrc(src);
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [src, hasConsent, updateObjectUrl]);
 
   const handleLoad = (event) => {
     setIsLoaded(true);
@@ -57,10 +160,23 @@ const AppImage = forwardRef(function AppImage({
   };
 
   const handleError = (event) => {
-    if (!hasTriedFallback && currentSrc !== FALLBACK_SRC) {
-      setHasTriedFallback(true);
-      setCurrentSrc(FALLBACK_SRC);
-      setIsLoaded(false);
+    if (!hasTriedFallback) {
+      if (currentSrc && currentSrc.startsWith("blob:") && src) {
+        setHasTriedFallback(true);
+        updateObjectUrl(null);
+        removeImageCacheEntry(src).catch(() => {});
+        setCurrentSrc(src);
+        setIsLoaded(false);
+        return;
+      }
+
+      if (currentSrc !== FALLBACK_SRC) {
+        setHasTriedFallback(true);
+        updateObjectUrl(null);
+        setCurrentSrc(FALLBACK_SRC);
+        setIsLoaded(false);
+        return;
+      }
     }
 
     onErrorProp?.(event);
@@ -98,7 +214,7 @@ const AppImage = forwardRef(function AppImage({
 
       <img
         ref={ref}
-        src={currentSrc}
+        src={currentSrc ?? undefined}
         alt={alt}
         className={cn("relative z-[2]", resolvedImgClassName)}
         onLoad={handleLoad}

--- a/resources/js/main/components/CookieConsentBanner.jsx
+++ b/resources/js/main/components/CookieConsentBanner.jsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  clearImageCache,
+  getImageCacheConsent,
+  IMAGE_CACHE_CONSENT_EVENT,
+  setImageCacheConsent,
+} from "@/lib/imageCache";
+
+const CONSENT_COPY = {
+  heading: "Permita armazenar imagens?",
+  body: "Guardamos em cache as imagens de destaque e galerias no seu navegador usando cookies/localStorage. Isso acelera visitas futuras, mas só será feito se você concordar.",
+  accept: "Aceitar e armazenar",
+  decline: "Recusar",
+};
+
+const CookieConsentBanner = () => {
+  const [consent, setConsent] = useState(() => getImageCacheConsent());
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const handleConsentChange = (event) => {
+      const nextConsent = event?.detail?.consent;
+      if (!nextConsent) return;
+      setConsent(nextConsent);
+    };
+
+    window.addEventListener(IMAGE_CACHE_CONSENT_EVENT, handleConsentChange);
+    return () => window.removeEventListener(IMAGE_CACHE_CONSENT_EVENT, handleConsentChange);
+  }, []);
+
+  const persistConsent = useCallback((nextConsent) => {
+    setImageCacheConsent(nextConsent);
+    setConsent(nextConsent);
+  }, []);
+
+  const handleAccept = useCallback(() => {
+    persistConsent("granted");
+  }, [persistConsent]);
+
+  const handleDecline = useCallback(() => {
+    persistConsent("denied");
+    clearImageCache().catch(() => {});
+  }, [persistConsent]);
+
+  if (!isHydrated || consent !== "unknown") {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-4 left-1/2 z-[1200] w-full max-w-xl -translate-x-1/2 rounded-lg border border-neutral-200 bg-white p-6 shadow-xl">
+      <h2 className="text-lg font-semibold text-neutral-900">{CONSENT_COPY.heading}</h2>
+      <p className="mt-2 text-sm text-neutral-700">{CONSENT_COPY.body}</p>
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+        <button
+          type="button"
+          onClick={handleDecline}
+          className="order-2 inline-flex justify-center rounded-md border border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100 sm:order-1"
+        >
+          {CONSENT_COPY.decline}
+        </button>
+        <button
+          type="button"
+          onClick={handleAccept}
+          className="order-1 inline-flex justify-center rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-2 sm:order-2"
+        >
+          {CONSENT_COPY.accept}
+        </button>
+      </div>
+      <p className="mt-3 text-xs text-neutral-500">
+        Você pode alterar essa decisão limpando os cookies do navegador. Sem consentimento, as páginas continuam funcionando, mas imagens pesadas serão baixadas novamente em cada visita.
+      </p>
+    </div>
+  );
+};
+
+export default CookieConsentBanner;


### PR DESCRIPTION
## Summary
- document AppImage progressive loading flow and wire it up to a consent-aware image cache helper
- add an imageCache utility that persists blobs via Cache Storage/IndexedDB with TTL metadata and consent tracking
- introduce a reusable cookie consent banner and mount it globally so marketing routes can request permission before caching

## Testing
- npm run types *(fails: existing TS2554 errors in resources/js/bootstrap/contact-bridge.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68d69a36a3a0832c9e07c142435db828