### PR TITLE
Simplify cookie consent message

### DIFF
--- a/resources/js/main/components/CookieConsentBanner.jsx
+++ b/resources/js/main/components/CookieConsentBanner.jsx
@@ -8,7 +8,7 @@ import {
 
 const CONSENT_COPY = {
   heading: "Permita armazenar imagens?",
-  body: "Guardamos em cache as imagens de destaque e galerias no seu navegador usando cookies/localStorage. Isso acelera visitas futuras, mas só será feito se você concordar.",
+  body: "Podemos salvar imagens para acelerar sua navegação?",
   accept: "Aceitar e armazenar",
   decline: "Recusar",
 };
@@ -73,7 +73,7 @@ const CookieConsentBanner = () => {
         </button>
       </div>
       <p className="mt-3 text-xs text-neutral-500">
-        Você pode alterar essa decisão limpando os cookies do navegador. Sem consentimento, as páginas continuam funcionando, mas imagens pesadas serão baixadas novamente em cada visita.
+        Você pode revisar essa escolha depois nas configurações do seu navegador.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- shorten the consent banner copy to a single, user-friendly question
- update the footer text to briefly explain the choice can be revisited later

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6a1b99030832cb484fdba6b0a6738