### PR TITLE
Add Helmet metadata to homepage

### DIFF
--- a/main/src/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/main/src/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
 import Header from '../../components/ui/Header';
 import HeroCarousel from './components/HeroCarousel';
 import FeaturedProperties from './components/FeaturedProperties';
@@ -31,6 +32,13 @@ const HomepagePremiumRealEstateConsultancy = () => {
 
   return (
     <div className="min-h-screen bg-white">
+      <Helmet>
+        <title>Casa Conecta Imóveis | Consultoria Imobiliária Premium</title>
+        <meta
+          name="description"
+          content="Descubra uma consultoria imobiliária premium com imóveis selecionados, atendimento personalizado e orientação especializada."
+        />
+      </Helmet>
       {/* Header */}
       <Header />
       

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
 import Header from '../../components/ui/Header';
 import HeroCarousel from './components/HeroCarousel';
 import FeaturedProperties from './components/FeaturedProperties';
@@ -31,6 +32,13 @@ const HomepagePremiumRealEstateConsultancy = () => {
 
   return (
     <div className="min-h-screen bg-white">
+      <Helmet>
+        <title>Casa Conecta Imóveis | Consultoria Imobiliária Premium</title>
+        <meta
+          name="description"
+          content="Descubra uma consultoria imobiliária premium com imóveis selecionados, atendimento personalizado e orientação especializada."
+        />
+      </Helmet>
       {/* Header */}
       <Header />
       


### PR DESCRIPTION
## Summary
- add Helmet integration to the premium homepage to define title and description
- mirror the metadata addition in the main bundle source

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6ce6a2c7c832c8d2b1517a4458252