### PR TITLE
Fix initial Inertia page title branding

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -6,10 +6,10 @@ import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createRoot } from 'react-dom/client';
 import { initializeTheme } from './hooks/use-appearance';
 
-const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+const appName = import.meta.env.VITE_APP_NAME || 'Casa Conecta Imóveis';
 
 createInertiaApp({
-    title: (title) => title ? `${title} - ${appName}` : appName,
+    title: (title) => title || appName,
     resolve: (name) => resolvePageComponent(`./pages/${name}.tsx`, import.meta.glob('./pages/**/*.tsx')),
     setup({ el, App, props }) {
         const root = createRoot(el);

--- a/resources/js/pages/site.tsx
+++ b/resources/js/pages/site.tsx
@@ -5,7 +5,7 @@ import '../../css/oldsite.css';
 export default function Site() {
   return (
     <div className="old-site">
-      <Head title="Site" />
+      <Head title="Casa Conecta Imóveis | Consultoria Imobiliária Premium" />
       <App />
     </div>
   );


### PR DESCRIPTION
## Summary
- update the Inertia site wrapper to send the full Casa Conecta Imóveis title on first render
- align the Inertia app fallback name and title handling so the delivered <title> matches the brand without duplication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6d1dcd824832ca05b1a8919515102