### PR TITLE
Delay homepage render until hero image is ready

### DIFF
--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Icon from '../../../components/AppIcon';
 import Image from '../../../components/AppImage';
 import Button from '../../../components/ui/Button';
@@ -140,10 +140,19 @@ const getHeroSlides = () => {
   return heroSlidesCache.promise;
 };
 
-const HeroCarousel = () => {
+const HeroCarousel = ({ onFirstSlideReady }) => {
   const [currentSlide, setCurrentSlide] = useState(0);
   const [heroProperties, setHeroProperties] = useState([]);
   const [loadedSlides, setLoadedSlides] = useState({});
+  const firstSlideReadyRef = useRef(false);
+
+  const notifyFirstSlideReady = useCallback(() => {
+    if (firstSlideReadyRef.current) return;
+    firstSlideReadyRef.current = true;
+    if (typeof onFirstSlideReady === 'function') {
+      onFirstSlideReady();
+    }
+  }, [onFirstSlideReady]);
 
   useEffect(() => {
     let isMounted = true;
@@ -188,6 +197,12 @@ const HeroCarousel = () => {
   useEffect(() => {
     setLoadedSlides({});
   }, [slides]);
+
+  useEffect(() => {
+    if (!slides.length) {
+      notifyFirstSlideReady();
+    }
+  }, [slides.length, notifyFirstSlideReady]);
 
   useEffect(() => {
     if (slides.length <= 1) return undefined;
@@ -251,6 +266,9 @@ const HeroCarousel = () => {
       ...prev,
       [index]: true,
     }));
+    if (index === 0) {
+      notifyFirstSlideReady();
+    }
   };
 
   const handleWhatsAppClick = (property) => {

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import Header from '../../components/ui/Header';
 import HeroCarousel from './components/HeroCarousel';
@@ -10,6 +10,8 @@ import ProcessTransparencySection from '../about-brand-story-credentials/compone
 import Footer from '../../components/Footer';
 
 const HomepagePremiumRealEstateConsultancy = () => {
+  const [isHeroReady, setIsHeroReady] = useState(false);
+
   useEffect(() => {
     // Smooth scroll behavior for anchor links
     const handleAnchorClick = (e) => {
@@ -31,7 +33,7 @@ const HomepagePremiumRealEstateConsultancy = () => {
   }, []);
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-white relative">
       <Helmet>
         <title>Casa Conecta Imóveis | Consultoria Imobiliária Premium</title>
         <meta
@@ -39,44 +41,65 @@ const HomepagePremiumRealEstateConsultancy = () => {
           content="Descubra uma consultoria imobiliária premium com imóveis selecionados, atendimento personalizado e orientação especializada."
         />
       </Helmet>
-      {/* Header */}
-      <Header />
-      
-      {/* Main Content */}
-      <main>
-        {/* Hero Carousel - Full viewport section */}
-        <HeroCarousel />
-        
-        {/* Featured Properties - Well organized section */}
-        <section className="section-spacing">
-          <div className="container-responsive">
-            <FeaturedProperties />
-          </div>
-        </section>
+      <div
+        className={`fixed inset-0 z-50 flex flex-col items-center justify-center bg-white transition-opacity duration-500 ${
+          isHeroReady ? 'opacity-0 pointer-events-none' : 'opacity-100'
+        }`}
+        aria-hidden={isHeroReady}
+      >
+        <img
+          src="/logo.png"
+          alt="Casa Conecta Imóveis"
+          className="w-32 h-auto mb-6"
+        />
+        <span className="sr-only">Carregando página inicial</span>
+        <div className="h-12 w-12 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+      </div>
 
-        {/* Neighborhood Map - Interactive section */}
-        <section className="section-spacing">
-          <div className="container-responsive">
-            <NeighborhoodMap />
-          </div>
-        </section>
+      <div
+        className={`transition-opacity duration-500 ${
+          isHeroReady ? 'opacity-100' : 'opacity-0 pointer-events-none select-none'
+        }`}
+      >
+        {/* Header */}
+        <Header />
 
-        {/* Expertise Section - Professional spacing */}
-        <section className="section-spacing">
-          <div className="container-responsive">
-            <ExpertiseSection />
-          </div>
-        </section>
+        {/* Main Content */}
+        <main>
+          {/* Hero Carousel - Full viewport section */}
+          <HeroCarousel onFirstSlideReady={() => setIsHeroReady(true)} />
 
-        {/* Transparent Process Section */}
-        <ProcessTransparencySection />
-      </main>
+          {/* Featured Properties - Well organized section */}
+          <section className="section-spacing">
+            <div className="container-responsive">
+              <FeaturedProperties />
+            </div>
+          </section>
 
-      {/* Footer */}
-      <Footer />
-      
-      {/* WhatsApp Float Button */}
-      <WhatsAppFloat />
+          {/* Neighborhood Map - Interactive section */}
+          <section className="section-spacing">
+            <div className="container-responsive">
+              <NeighborhoodMap />
+            </div>
+          </section>
+
+          {/* Expertise Section - Professional spacing */}
+          <section className="section-spacing">
+            <div className="container-responsive">
+              <ExpertiseSection />
+            </div>
+          </section>
+
+          {/* Transparent Process Section */}
+          <ProcessTransparencySection />
+        </main>
+
+        {/* Footer */}
+        <Footer />
+
+        {/* WhatsApp Float Button */}
+        <WhatsAppFloat />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- expose an optional onFirstSlideReady callback in the hero carousel that fires when the first slide or fallback is ready
- block the homepage content behind the hero readiness flag and show a branded loading overlay to avoid flashing an empty hero

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d6d39e6f7c832cb2631bc8bc4db3df