### PR TITLE
Hold homepage render until hero image loads and drop consent banner

### DIFF
--- a/resources/js/lib/imageCache.ts
+++ b/resources/js/lib/imageCache.ts
@@ -263,7 +263,7 @@ export function getImageCacheConsent(): ImageCacheConsent {
     return cookie;
   }
 
-  return "unknown";
+  return "granted";
 }
 
 export function hasImageCacheConsent(): boolean {

--- a/resources/js/main/Routes.jsx
+++ b/resources/js/main/Routes.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import { BrowserRouter, Routes as RouterRoutes, Route } from "react-router-dom";
 import ErrorBoundary from "@/main/components/ErrorBoundary";
 import ScrollToTop from "@/main/components/ScrollToTop";
-import CookieConsentBanner from "@/main/components/CookieConsentBanner";
 import NotFound from "@/main/pages/NotFound";
 import FAQPage from './pages/faq-comprehensive-buyer-education';
 import AboutBrandStoryCredentials from './pages/about-brand-story-credentials';
@@ -21,7 +20,6 @@ const Routes = () => {
     <BrowserRouter>
       <ErrorBoundary>
         <ScrollToTop />
-        <CookieConsentBanner />
         <AnalyticsWrapper>
           <RouterRoutes>
             {/* Define your route here */}

--- a/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
+++ b/resources/js/main/pages/homepage-premium-real-estate-consultancy/components/HeroCarousel.jsx
@@ -144,6 +144,7 @@ const HeroCarousel = ({ onFirstSlideReady }) => {
   const [currentSlide, setCurrentSlide] = useState(0);
   const [heroProperties, setHeroProperties] = useState([]);
   const [loadedSlides, setLoadedSlides] = useState({});
+  const [isLoadingSlides, setIsLoadingSlides] = useState(true);
   const firstSlideReadyRef = useRef(false);
 
   const notifyFirstSlideReady = useCallback(() => {
@@ -159,17 +160,22 @@ const HeroCarousel = ({ onFirstSlideReady }) => {
 
     if (heroSlidesCache.data) {
       setHeroProperties(heroSlidesCache.data);
+      setIsLoadingSlides(false);
+    } else {
+      setIsLoadingSlides(true);
     }
 
     getHeroSlides()
       .then((slides) => {
-        if (isMounted) {
-          setHeroProperties(slides);
-        }
+        if (!isMounted) return;
+        setHeroProperties(slides);
+        setIsLoadingSlides(false);
       })
       .catch(() => {
+        if (!isMounted) return;
         // Já tentamos usar o cache acima; se a requisição falhar e não houver
         // dados anteriores não podemos fazer muito além de manter o fallback.
+        setIsLoadingSlides(false);
       });
 
     return () => {
@@ -199,10 +205,10 @@ const HeroCarousel = ({ onFirstSlideReady }) => {
   }, [slides]);
 
   useEffect(() => {
-    if (!slides.length) {
+    if (!isLoadingSlides && !slides.length) {
       notifyFirstSlideReady();
     }
-  }, [slides.length, notifyFirstSlideReady]);
+  }, [isLoadingSlides, slides.length, notifyFirstSlideReady]);
 
   useEffect(() => {
     if (slides.length <= 1) return undefined;


### PR DESCRIPTION
## Summary
- ensure the homepage overlay only dismisses after the first hero slide loads by tracking the slide fetch lifecycle
- remove the cookie consent banner from the public router and default the image cache consent to granted so cached blobs continue to be used

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d68ef4f398832caba1d93e630d5b1d