### PR TITLE
Fix PDV client Select2 styling

### DIFF
--- a/resources/css/oldsite.css
+++ b/resources/css/oldsite.css
@@ -81,6 +81,104 @@
   padding: 0.5rem 0.75rem; /* px-3 py-2 */
 }
 
+/* ===================== Ajustes de Select2 para o PDV ===================== */
+/*
+ * Os novos templates Select2 usados no PDV exibem o nome na primeira linha e
+ * o CPF/CNPJ formatado logo abaixo. O bloco abaixo garante que tanto a opção
+ * selecionada quanto a listagem no dropdown mantenham uma aparência coerente
+ * com os demais campos do painel legacy.
+ */
+
+/* Contêiner principal (estado fechado) */
+.old-site #clienteInput2 + .select2-container--default .select2-selection--single,
+.old-site #modalVendaWrapper #clienteInput2 + .select2-container--default .select2-selection--single {
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-border);
+  background-color: #FFFFFF;
+  min-height: 2.75rem;
+  height: auto;
+  display: flex;
+  align-items: center;
+  transition: border-color 150ms ease-in-out, box-shadow 150ms ease-in-out;
+}
+
+/* Aparência quando o componente recebe foco */
+.old-site #clienteInput2 + .select2-container--default.select2-container--focus .select2-selection--single,
+.old-site #modalVendaWrapper #clienteInput2 + .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.15);
+}
+
+/* Conteúdo renderizado na área selecionada */
+.old-site #clienteInput2 + .select2-container--default .select2-selection--single .select2-selection__rendered,
+.old-site #modalVendaWrapper #clienteInput2 + .select2-container--default .select2-selection--single .select2-selection__rendered {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 0.15rem;
+  width: 100%;
+  padding: 0.35rem 0.75rem;
+  line-height: 1.25;
+  color: var(--color-text-primary);
+}
+
+.old-site #clienteInput2 + .select2-container--default .select2-selection--single .select2-selection__placeholder,
+.old-site #modalVendaWrapper #clienteInput2 + .select2-container--default .select2-selection--single .select2-selection__placeholder {
+  color: var(--color-text-secondary);
+}
+
+/* Mantém o ícone de seta alinhado ao topo da seleção multi-linha */
+.old-site #clienteInput2 + .select2-container--default .select2-selection--single .select2-selection__arrow,
+.old-site #modalVendaWrapper #clienteInput2 + .select2-container--default .select2-selection--single .select2-selection__arrow {
+  height: 100%;
+  top: 0;
+}
+
+/* Ajusta o espaçamento interno do dropdown para suportar duas linhas */
+.old-site .select2-container--default .select2-results > .select2-results__options {
+  padding: 0.25rem 0;
+}
+
+.old-site .select2-container--default .select2-results__option {
+  padding: 0.35rem 0.75rem;
+  transition: background-color 100ms ease-in-out;
+}
+
+.old-site .select2-container--default .select2-results__option--highlighted[aria-selected] {
+  background-color: rgba(34, 197, 94, 0.1);
+  color: var(--color-text-primary);
+}
+
+/* Template customizado das opções do cliente */
+.old-site .select2-results__option .cliente-option,
+.old-site .select2-selection__rendered .cliente-selection {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  width: 100%;
+}
+
+.old-site .cliente-option__nome,
+.old-site .cliente-selection__nome {
+  font-weight: 600;
+  color: var(--color-text-primary);
+  line-height: 1.25;
+}
+
+.old-site .cliente-option__documento,
+.old-site .cliente-selection__documento {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  line-height: 1.2;
+}
+
+/* Permite que as descrições quebrem linha sem ultrapassar o container */
+.old-site .select2-container--default .select2-results__option {
+  white-space: normal;
+}
+
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
 .old-site .pulse-animation { animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
 


### PR DESCRIPTION
## Summary
- adjust the PDV client Select2 selection container so the name/document layout stays aligned with the old-site visual language
- style the client option templates inside the Select2 dropdown to keep two-line entries legible and consistent

## Testing
- php artisan test *(fails: MissingAppKeyException because no application key is configured in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68d6d87e07f8832c8d69f96f67571157