### PR TITLE
Improve image upload reliability and performance

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -26,22 +26,23 @@ class ImageController extends Controller
         $disk = 'public';
 
         foreach ($request->file('images', []) as $file) {
-            $path = $file->store('images', $disk);
-            $filename = basename($path);
-            $size = $file->getSize();
-            $mime = $file->getMimeType();
-
             $width = null;
             $height = null;
             try {
-                $absolute = Storage::disk($disk)->path($path);
-                if (is_file($absolute)) {
-                    [$w, $h] = @getimagesize($absolute) ?: [null, null];
-                    $width = $w; $height = $h;
+                $realPath = $file->getRealPath();
+                if ($realPath && is_file($realPath)) {
+                    [$w, $h] = @getimagesize($realPath) ?: [null, null];
+                    $width = $w;
+                    $height = $h;
                 }
             } catch (\Throwable $e) {
                 // ignora falhas ao ler dimensões
             }
+
+            $path = $file->store('images', $disk);
+            $filename = basename($path);
+            $size = $file->getSize();
+            $mime = $file->getMimeType();
 
             $image = Image::create([
                 'disk'          => $disk,

--- a/resources/js/lib/api.ts
+++ b/resources/js/lib/api.ts
@@ -1,7 +1,30 @@
-export const getCsrf = () =>
-    typeof document !== 'undefined'
-        ? ((document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content ?? '')
-        : '';
+const getCookie = (name: string): string => {
+    if (typeof document === 'undefined') return '';
+
+    const target = `${name}=`;
+    const raw = document.cookie
+        .split(';')
+        .map((cookie) => cookie.trim())
+        .find((cookie) => cookie.startsWith(target));
+
+    if (!raw) return '';
+
+    const value = raw.slice(target.length);
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+};
+
+export const getCsrf = () => {
+    if (typeof document === 'undefined') return '';
+
+    const metaToken = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content;
+    if (metaToken) return metaToken;
+
+    return getCookie('XSRF-TOKEN');
+};
 
 export async function apiFetch<T = unknown>(def: { url: string; method?: string }, init?: RequestInit): Promise<T> {
     const method = (def.method ?? 'get').toUpperCase();


### PR DESCRIPTION
## Summary
- fallback to the XSRF-TOKEN cookie when the meta csrf token is unavailable in the SPA build
- avoid reopening stored files when extracting dimensions during image upload to reduce I/O overhead

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6e113a22c832c90e54d5fe1c57a6a