### PR TITLE
Queue image metadata processing and harden upload error handling

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\ProcessUploadedImage;
 use App\Models\Image;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -26,19 +27,6 @@ class ImageController extends Controller
         $disk = 'public';
 
         foreach ($request->file('images', []) as $file) {
-            $width = null;
-            $height = null;
-            try {
-                $realPath = $file->getRealPath();
-                if ($realPath && is_file($realPath)) {
-                    [$w, $h] = @getimagesize($realPath) ?: [null, null];
-                    $width = $w;
-                    $height = $h;
-                }
-            } catch (\Throwable $e) {
-                // ignora falhas ao ler dimensões
-            }
-
             $path = $file->store('images', $disk);
             $filename = basename($path);
             $size = $file->getSize();
@@ -51,9 +39,11 @@ class ImageController extends Controller
                 'original_name' => $file->getClientOriginalName(),
                 'size'          => $size,
                 'mime_type'     => $mime,
-                'width'         => $width,
-                'height'        => $height,
+                'width'         => null,
+                'height'        => null,
             ]);
+
+            ProcessUploadedImage::dispatch($image);
 
             $saved[] = $image;
         }

--- a/app/Jobs/ProcessUploadedImage.php
+++ b/app/Jobs/ProcessUploadedImage.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Image;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class ProcessUploadedImage implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public Image $image)
+    {
+    }
+
+    public function handle(): void
+    {
+        $image = $this->image->fresh();
+        if (!$image) {
+            return;
+        }
+
+        if (!is_null($image->width) && !is_null($image->height)) {
+            return;
+        }
+
+        try {
+            $disk = Storage::disk($image->disk);
+        } catch (\Throwable $e) {
+            Log::warning('ProcessUploadedImage: failed to resolve disk', ['image_id' => $image->id, 'exception' => $e]);
+            return;
+        }
+
+        $path = null;
+        $temporaryPath = null;
+
+        try {
+            if (method_exists($disk, 'path')) {
+                $path = $disk->path($image->path);
+            } else {
+                $stream = $disk->readStream($image->path);
+                if ($stream === false) {
+                    return;
+                }
+
+                $temporaryPath = tempnam(sys_get_temp_dir(), 'img-');
+                if ($temporaryPath === false) {
+                    fclose($stream);
+                    return;
+                }
+
+                $destination = fopen($temporaryPath, 'wb');
+                if ($destination === false) {
+                    fclose($stream);
+                    return;
+                }
+
+                try {
+                    stream_copy_to_stream($stream, $destination);
+                } finally {
+                    fclose($stream);
+                    fclose($destination);
+                }
+
+                $path = $temporaryPath;
+            }
+        } catch (\Throwable $e) {
+            Log::warning('ProcessUploadedImage: unable to access file', ['image_id' => $image->id, 'exception' => $e]);
+            if ($temporaryPath && is_file($temporaryPath)) {
+                @unlink($temporaryPath);
+            }
+            return;
+        }
+
+        if (!$path || !is_file($path)) {
+            if ($temporaryPath && is_file($temporaryPath)) {
+                @unlink($temporaryPath);
+            }
+            return;
+        }
+
+        try {
+            [$width, $height] = @getimagesize($path) ?: [null, null];
+        } catch (\Throwable $e) {
+            Log::debug('ProcessUploadedImage: getimagesize failed', ['image_id' => $image->id, 'exception' => $e]);
+            if ($temporaryPath && is_file($temporaryPath)) {
+                @unlink($temporaryPath);
+            }
+            return;
+        } finally {
+            if ($temporaryPath && is_file($temporaryPath)) {
+                @unlink($temporaryPath);
+            }
+        }
+
+        if (is_null($width) || is_null($height)) {
+            return;
+        }
+
+        $image->forceFill([
+            'width' => $width,
+            'height' => $height,
+        ])->save();
+    }
+}

--- a/resources/js/lib/api.ts
+++ b/resources/js/lib/api.ts
@@ -42,6 +42,12 @@ export async function apiFetch<T = unknown>(def: { url: string; method?: string 
         const text = await res.text();
         throw new Error(text || `HTTP ${res.status}`);
     }
+
     const ct = res.headers.get('content-type') || '';
-    return (ct.includes('application/json') ? res.json() : (null as unknown)) as T;
+    if (!ct.toLowerCase().includes('application/json')) {
+        const bodyText = (await res.text()).trim();
+        throw new Error(bodyText || 'Resposta inesperada do servidor');
+    }
+
+    return (await res.json()) as T;
 }

--- a/resources/js/pages/painel.tsx
+++ b/resources/js/pages/painel.tsx
@@ -165,6 +165,9 @@ export default function Painel() {
         setImagesUploading(true);
         try {
             const uploaded = await apiFetch<Image[]>(ImageActions.store(), { body: fd });
+            if (!Array.isArray(uploaded)) {
+                throw new Error('Resposta inesperada do servidor');
+            }
             setNotice({ type: 'success', title: 'Imagens enviadas com sucesso' });
             return uploaded;
         } catch (e) {


### PR DESCRIPTION
## Summary
- store uploaded images immediately and dispatch a queued job to populate dimensions later
- add the `ProcessUploadedImage` job to safely read dimensions from any filesystem driver
- harden the panel upload flow by throwing on non-JSON responses and validating the returned payload

## Testing
- php artisan test *(fails: MissingAppKeyException – no application encryption key configured in test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d6eae8965c832c8ff537f8d2d8cb08